### PR TITLE
Migrate to TanStack template with separate API

### DIFF
--- a/apps/ottabase-template-app-tanstack/package.json
+++ b/apps/ottabase-template-app-tanstack/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "dev:worker": "wrangler dev --port 8790",
+    "dev:full": "pnpm build && pnpm dev:worker",
     "build": "vite build",
     "preview": "pnpm build && wrangler dev",
     "deploy": "pnpm build && wrangler deploy",

--- a/apps/ottabase-template-app-tanstack/vite.config.ts
+++ b/apps/ottabase-template-app-tanstack/vite.config.ts
@@ -25,6 +25,13 @@ export default defineConfig(async () => {
     server: {
       port: 5174,
       strictPort: true,
+      proxy: {
+        "/api": {
+          target: "http://localhost:8790",
+          changeOrigin: true,
+          secure: false,
+        },
+      },
     },
   };
 });


### PR DESCRIPTION
- Add Vite proxy config to forward /api requests to Wrangler dev server
- Add dev:worker script to run Cloudflare Worker with API routes
- Add dev:full script for complete local development setup
- Fixes 404 errors when accessing API routes during development

Now developers can run both frontend and API routes together in dev mode.