### PR TITLE
Fix OttaEditor styling in TanStack template app

### DIFF
--- a/apps/ottabase-template-app-tanstack/src/pages/demo/ottaeditor/EditorClient.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/demo/ottaeditor/EditorClient.tsx
@@ -140,7 +140,7 @@ export function EditorClient() {
                             Reload Sample
                         </Button>
                     </div>
-                    <div ref={editor1.editorRef} className="min-h-[300px] max-w-none rounded-lg border p-4" />
+                    <div ref={editor1.editorRef} className="min-h-[300px] prose prose-slate dark:prose-invert max-w-none rounded-lg border p-4" />
                     {savedData1 ? (
                         <details className="mt-4">
                             <summary className="cursor-pointer text-sm font-semibold">
@@ -182,7 +182,7 @@ export function EditorClient() {
                             Reload Sample
                         </Button>
                     </div>
-                    <div ref={editor2.editorRef} className="min-h-[300px] max-w-none rounded-lg border p-4" />
+                    <div ref={editor2.editorRef} className="min-h-[300px] prose prose-slate dark:prose-invert max-w-none rounded-lg border p-4" />
                     {savedData2 ? (
                         <details className="mt-4">
                             <summary className="cursor-pointer text-sm font-semibold">


### PR DESCRIPTION
Add missing Tailwind Typography prose classes to editor containers. The Next.js template had prose classes for proper H1, H2, and other HTML element styling, but they were missing in the TanStack app.

Added classes: prose prose-slate dark:prose-invert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced editor interface with improved typography styling for better readability and visual presentation.
  * Added dark mode support to editor containers for consistent theming across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->