### PR TITLE
Fix TanStack router browser refresh redirecting to homepage

### DIFF
--- a/apps/ottabase-template-app-tanstack/vite.config.ts
+++ b/apps/ottabase-template-app-tanstack/vite.config.ts
@@ -1,6 +1,36 @@
-import { defineConfig } from "vite";
+import { defineConfig, Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
+import fs from "node:fs";
+
+// SPA fallback plugin for client-side routing
+function spaFallback(): Plugin {
+  return {
+    name: "spa-fallback",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        // Skip API routes
+        if (req.url?.startsWith("/api")) {
+          return next();
+        }
+
+        // Skip asset requests (files with extensions)
+        const hasExtension = /\.[a-zA-Z0-9]+$/.test(req.url || "");
+        if (hasExtension) {
+          return next();
+        }
+
+        // For HTML requests without extensions, serve index.html
+        const acceptsHtml = req.headers.accept?.includes("text/html");
+        if (acceptsHtml) {
+          req.url = "/index.html";
+        }
+
+        next();
+      });
+    },
+  };
+}
 
 export default defineConfig(async () => {
   const { default: tsconfigPaths } = await import("vite-tsconfig-paths");
@@ -12,6 +42,7 @@ export default defineConfig(async () => {
         ignoreConfigErrors: true,
       }),
       react(),
+      spaFallback(),
     ],
     resolve: {
       alias: {
@@ -32,6 +63,9 @@ export default defineConfig(async () => {
           secure: false,
         },
       },
+    },
+    preview: {
+      port: 4173,
     },
   };
 });

--- a/apps/ottabase-template-app-tanstack/vite.config.ts
+++ b/apps/ottabase-template-app-tanstack/vite.config.ts
@@ -14,7 +14,8 @@ function spaFallback(): Plugin {
         }
 
         // Skip asset requests (files with extensions)
-        const hasExtension = /\.[a-zA-Z0-9]+$/.test(req.url || "");
+        const urlPath = (req.url || "").split(/[?#]/, 1)[0];
+        const hasExtension = /\.[a-zA-Z0-9]+$/.test(urlPath);
         if (hasExtension) {
           return next();
         }

--- a/apps/ottabase-template-app-tanstack/vite.config.ts
+++ b/apps/ottabase-template-app-tanstack/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig, Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
-import fs from "node:fs";
 
 // SPA fallback plugin for client-side routing
 function spaFallback(): Plugin {


### PR DESCRIPTION
Add SPA fallback middleware to Vite dev server to properly handle client-side routing. When navigating to a route and refreshing the browser, the dev server now serves index.html instead of returning a 404, allowing TanStack Router to handle the route correctly.

The fix includes:
- Custom spaFallback() plugin that intercepts HTML requests
- Skips API routes and static assets
- Redirects navigation requests to index.html
- Matches production behavior in cloudflare-worker.ts

This resolves the issue where refreshing on routes like /demo/cloudflare would incorrectly load the homepage instead of the current route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved SPA fallback behavior so the app correctly serves the main page for extensionless URLs while leaving API and asset requests untouched, reducing navigation errors in single‑page workflows.
  * Set an explicit preview server port (4173) to ensure consistent local preview behavior across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->