### PR TITLE
Rename ASSETS binding to OBCF_ASSETS

### DIFF
--- a/apps/ottabase-template-app-tanstack/cloudflare-worker.ts
+++ b/apps/ottabase-template-app-tanstack/cloudflare-worker.ts
@@ -741,13 +741,13 @@ export default {
 
     // Serve built assets. If the asset isn't found and the client is requesting HTML,
     // fall back to `index.html` to support client-side routing.
-    const response = await env.ASSETS.fetch(request);
+    const response = await env.OBCF_ASSETS.fetch(request);
     if (response.status !== 404 || !isHtmlRequest(request)) {
       return response;
     }
 
     const indexUrl = new URL(request.url);
     indexUrl.pathname = "/index.html";
-    return env.ASSETS.fetch(new Request(indexUrl.toString(), request));
+    return env.OBCF_ASSETS.fetch(new Request(indexUrl.toString(), request));
   },
 };

--- a/apps/ottabase-template-app-tanstack/wrangler.jsonc
+++ b/apps/ottabase-template-app-tanstack/wrangler.jsonc
@@ -102,7 +102,7 @@
   // Vite build outputs to dist/ directory
   "assets": {
     "directory": "dist",
-    "binding": "ASSETS"
+    "binding": "OBCF_ASSETS"
   },
 
   // Environment variables
@@ -140,7 +140,7 @@
       },
       // Production assets
       "assets": {
-        "binding": "ASSETS",
+        "binding": "OBCF_ASSETS",
         "directory": "dist"
       },
       // Production D1 Database - set via CI/CD substitution or manually

--- a/apps/ottabase-template-app/types/cloudflare.d.ts
+++ b/apps/ottabase-template-app/types/cloudflare.d.ts
@@ -51,8 +51,8 @@ export interface CloudflareEnv {
   CF_ACCOUNT_ID?: string;
   CF_API_TOKEN?: string;
 
-  // Assets binding (automatically added by OpenNext)
-  ASSETS?: Fetcher;
+  // Assets binding (OBCF = Ottabase Cloudflare)
+  OBCF_ASSETS?: Fetcher;
 }
 
 /**

--- a/apps/ottabase-template-app/wrangler.jsonc
+++ b/apps/ottabase-template-app/wrangler.jsonc
@@ -29,7 +29,7 @@
   // Asset and Image bindings
   "assets": {
     "directory": ".open-next/assets",
-    "binding": "ASSETS",
+    "binding": "OBCF_ASSETS",
   },
   "images": {
     "binding": "IMAGES",
@@ -186,7 +186,7 @@
       },
       // Asset and Image bindings for Production
       "assets": {
-        "binding": "ASSETS",
+        "binding": "OBCF_ASSETS",
         "directory": ".open-next/assets",
       },
       "images": {


### PR DESCRIPTION
Updated the asset binding name from ASSETS to OBCF_ASSETS in:
- Cloudflare worker code (cloudflare-worker.ts)
- Environment types (cloudflare.d.ts)
- Wrangler configuration files for both template apps

This change ensures consistency with the OBCF_* naming convention used for other Cloudflare bindings and avoids potential conflicts.