### PR TITLE
Update deployment logic with configurable app list

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -23,13 +23,13 @@ Complete reference for the deployment system. See [README.md](README.md) for qui
 
 ## Framework Examples
 
-### TanStack Start (Default)
+### TanStack (Default)
 
 **package.json:**
 ```json
 {
   "scripts": {
-    "build": "vinxi build"
+    "build": "vite build"
   }
 }
 ```

--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -7,13 +7,13 @@ Complete reference for the deployment system. See [README.md](README.md) for qui
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `deployable` | boolean | `true` | Whether to deploy this app |
-| `appType` | string | `"nextjs"` | App framework (`nextjs`, `react`, `remix`, `vite`, `custom`) |
+| `appType` | string | `"tanstack"` | App framework (`tanstack`, `nextjs`, `react`, `remix`, `vite`, `custom`) |
 | `workerName` | string | package name | Cloudflare Worker name |
 | `buildCommand` | string | `"build"` | pnpm script to build app |
-| `workerBuildCommand` | string | `"build:worker"` | pnpm script to build Worker bundle |
-| `outputDirectory` | string | `".worker-next"` | Worker output directory |
-| `assetsDirectory` | string | `".worker-next/assets"` | Static assets directory |
-| `verifyPaths` | string[] | `[".worker-next"]` | Paths to verify after build |
+| `workerBuildCommand` | string | `null` | pnpm script to build Worker bundle (null for TanStack) |
+| `outputDirectory` | string | `"dist"` | Worker output directory |
+| `assetsDirectory` | string | - | Static assets directory |
+| `verifyPaths` | string[] | `["dist", "cloudflare-worker.ts"]` | Paths to verify after build |
 | `wranglerConfig` | string | `"wrangler.jsonc"` | Wrangler config file path |
 | `wranglerEnv` | string | `"production"` | Wrangler environment |
 | `healthCheckPath` | string | `"/"` | Path for health check |
@@ -22,6 +22,31 @@ Complete reference for the deployment system. See [README.md](README.md) for qui
 **Default Secrets:** `["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"]`
 
 ## Framework Examples
+
+### TanStack Start (Default)
+
+**package.json:**
+```json
+{
+  "scripts": {
+    "build": "vinxi build"
+  }
+}
+```
+
+**cloudflare-config.json:**
+```json
+{
+  "deployable": true,
+  "appType": "tanstack",
+  "workerName": "my-tanstack-app",
+  "buildCommand": "build",
+  "workerBuildCommand": null,
+  "outputDirectory": "dist",
+  "verifyPaths": ["dist", "cloudflare-worker.ts"],
+  "requiresSecrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "D1_DATABASE_ID", "KV_NAMESPACE_ID"]
+}
+```
 
 ### Next.js with OpenNext
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -10,7 +10,7 @@ Dynamic CI/CD system for deploying apps to Cloudflare Workers with automatic dis
    ```json
    {
      "deployable": true,
-     "appType": "nextjs"
+     "appType": "tanstack"
    }
    ```
 
@@ -22,7 +22,15 @@ Already configured. Just push to `main`.
 
 ## Configuration
 
-### Minimal (uses defaults)
+### Minimal TanStack (default)
+```json
+{
+  "deployable": true,
+  "appType": "tanstack"
+}
+```
+
+### Minimal Next.js
 ```json
 {
   "deployable": true,
@@ -57,8 +65,19 @@ Already configured. Just push to `main`.
 - `D1_DATABASE_ID` - (if using D1) From `wrangler d1 create <name>`
 - `KV_NAMESPACE_ID` - (if using KV) From `wrangler kv:namespace create <name>`
 
-## Build Flow (Next.js)
+## Build Flow
 
+### TanStack Start (Default)
+```bash
+# Step 1: Vinxi build
+vinxi build
+# → Output: dist/
+
+# Step 2: Deploy to Cloudflare Workers
+wrangler deploy --env production
+```
+
+### Next.js
 ```bash
 # Step 1: Next.js build
 next build
@@ -74,7 +93,8 @@ wrangler deploy --env production
 
 ## Supported App Types
 
-- `nextjs` - Next.js + OpenNext (default)
+- `tanstack` - TanStack Start (default)
+- `nextjs` - Next.js + OpenNext
 - `react` - React + Vite
 - `remix` - Remix
 - `vite` - Vite apps

--- a/.github/README.md
+++ b/.github/README.md
@@ -67,10 +67,10 @@ Already configured. Just push to `main`.
 
 ## Build Flow
 
-### TanStack Start (Default)
+### TanStack (Default)
 ```bash
-# Step 1: Vinxi build
-vinxi build
+# Step 1: Vite build
+vite build
 # → Output: dist/
 
 # Step 2: Deploy to Cloudflare Workers
@@ -93,7 +93,7 @@ wrangler deploy --env production
 
 ## Supported App Types
 
-- `tanstack` - TanStack Start (default)
+- `tanstack` - TanStack Router + Vite (default)
 - `nextjs` - Next.js + OpenNext
 - `react` - React + Vite
 - `remix` - Remix

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,18 +162,18 @@ jobs:
                 echo "⚠️  Warning: No cloudflare-config.json or wrangler.jsonc for ${app_folder}, skipping"
                 continue
               fi
-              # Use defaults
+              # Use TanStack defaults (default template app is TanStack)
               CONFIG='{
                 "deployable": true,
-                "appType": "nextjs",
+                "appType": "tanstack",
                 "buildCommand": "build",
-                "workerBuildCommand": "build:worker",
-                "outputDirectory": ".open-next",
-                "verifyPaths": [".open-next"],
+                "workerBuildCommand": null,
+                "outputDirectory": "dist",
+                "verifyPaths": ["dist", "cloudflare-worker.ts"],
                 "wranglerConfig": "wrangler.jsonc",
                 "wranglerEnv": "production",
                 "healthCheckPath": "/",
-                "requiresSecrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"]
+                "requiresSecrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "D1_DATABASE_ID", "KV_NAMESPACE_ID"]
               }'
             fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,25 +7,46 @@ on:
   workflow_dispatch: # Allow manual triggers
 
 jobs:
-  # Detect which files changed in the last commit
-  detect-changes:
+  # Prepare deployment matrix based on target apps and code changes
+  prepare-deployment:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    name: Detect file changes
+    name: Prepare deployment
     outputs:
-      packages-changed: ${{ steps.changes.outputs.packages-changed }}
-      changed-apps: ${{ steps.changes.outputs.changed-apps }}
-      should-deploy: ${{ steps.changes.outputs.should-deploy }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has-apps: ${{ steps.build-matrix.outputs.has-apps }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 2  # Need previous commit to compare
 
-      - name: Detect changed files
-        id: changes
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Build deployment matrix
+        id: build-matrix
         run: |
-          echo "🔍 Detecting file changes in the last commit..."
+          echo "🔍 Preparing deployment matrix..."
+
+          # Step 1: Get target apps from secret or use default
+          APPS_TO_DEPLOY="${{ secrets.APPS_TO_DEPLOY }}"
+          if [ -z "$APPS_TO_DEPLOY" ]; then
+            APPS_TO_DEPLOY="ottabase-template-app-tanstack"
+            echo "📋 Using default app: ${APPS_TO_DEPLOY}"
+          else
+            echo "📋 Apps from secret: ${APPS_TO_DEPLOY}"
+          fi
+
+          # Convert comma-separated string to array
+          IFS=',' read -ra TARGET_APPS <<< "$APPS_TO_DEPLOY"
+          echo "🎯 Target apps: ${TARGET_APPS[*]}"
+
+          # Step 2: Detect file changes
+          echo ""
+          echo "🔍 Detecting file changes..."
 
           # Get list of changed files in the last commit
           CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD)
@@ -34,165 +55,177 @@ jobs:
           echo "$CHANGED_FILES"
           echo ""
 
-          # Check if any packages changed
+          # Check if packages changed
           PACKAGES_CHANGED="false"
           if echo "$CHANGED_FILES" | grep -q "^packages/"; then
             PACKAGES_CHANGED="true"
-            echo "📦 Packages changed - will deploy all apps"
+            echo "📦 Packages changed - will deploy all target apps"
           fi
-          echo "packages-changed=${PACKAGES_CHANGED}" >> $GITHUB_OUTPUT
 
-          # Find which apps have changes
-          CHANGED_APPS=""
+          # For workflow_dispatch, treat as if packages changed (deploy all)
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PACKAGES_CHANGED="true"
+            echo "🔄 Manual trigger - will deploy all target apps"
+          fi
+
+          # Find which apps have code changes
+          CHANGED_APP_FOLDERS=""
           while IFS= read -r file; do
             if [[ "$file" =~ ^apps/([^/]+)/ ]]; then
               APP_FOLDER="${BASH_REMATCH[1]}"
-              # Add to list if not already present
-              if [[ ! "$CHANGED_APPS" =~ (^|,)$APP_FOLDER(,|$) ]]; then
-                if [ -n "$CHANGED_APPS" ]; then
-                  CHANGED_APPS="${CHANGED_APPS},${APP_FOLDER}"
+              if [[ ! "$CHANGED_APP_FOLDERS" =~ (^|,)$APP_FOLDER(,|$) ]]; then
+                if [ -n "$CHANGED_APP_FOLDERS" ]; then
+                  CHANGED_APP_FOLDERS="${CHANGED_APP_FOLDERS},${APP_FOLDER}"
                 else
-                  CHANGED_APPS="${APP_FOLDER}"
+                  CHANGED_APP_FOLDERS="${APP_FOLDER}"
                 fi
               fi
             fi
           done <<< "$CHANGED_FILES"
 
-          echo "changed-apps=${CHANGED_APPS}" >> $GITHUB_OUTPUT
-
-          if [ -n "$CHANGED_APPS" ]; then
-            echo "🎯 Apps with changes: ${CHANGED_APPS}"
+          if [ -n "$CHANGED_APP_FOLDERS" ]; then
+            echo "🎯 Apps with changes: ${CHANGED_APP_FOLDERS}"
           fi
 
-          # Determine if we should deploy
-          SHOULD_DEPLOY="false"
-          if [ "$PACKAGES_CHANGED" == "true" ] || [ -n "$CHANGED_APPS" ]; then
-            SHOULD_DEPLOY="true"
-          fi
-          echo "should-deploy=${SHOULD_DEPLOY}" >> $GITHUB_OUTPUT
+          # Step 3: Determine which target apps to deploy
+          APPS_TO_BUILD=()
 
-          # For workflow_dispatch, always deploy
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "🔄 Manual trigger - will deploy all apps"
-            echo "should-deploy=true" >> $GITHUB_OUTPUT
-            echo "packages-changed=true" >> $GITHUB_OUTPUT
-          fi
+          for target_app in "${TARGET_APPS[@]}"; do
+            # Trim whitespace
+            target_app=$(echo "$target_app" | xargs)
 
+            # Check if this is a folder name or package name
+            # Try to find the app folder
+            APP_FOLDER=""
+            if [ -d "apps/${target_app}" ]; then
+              APP_FOLDER="${target_app}"
+            else
+              # Search for package name in apps
+              for dir in apps/*/; do
+                if [ -f "${dir}package.json" ]; then
+                  PKG_NAME=$(cat "${dir}package.json" | grep '"name"' | head -1 | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+                  if [ "$PKG_NAME" == "$target_app" ]; then
+                    APP_FOLDER=$(basename "$dir")
+                    break
+                  fi
+                fi
+              done
+            fi
+
+            if [ -z "$APP_FOLDER" ]; then
+              echo "⚠️  Warning: Could not find app '${target_app}', skipping"
+              continue
+            fi
+
+            # Check if we should deploy this app
+            SHOULD_DEPLOY="false"
+            if [ "$PACKAGES_CHANGED" == "true" ]; then
+              SHOULD_DEPLOY="true"
+            elif [[ ",$CHANGED_APP_FOLDERS," == *",$APP_FOLDER,"* ]]; then
+              SHOULD_DEPLOY="true"
+            fi
+
+            if [ "$SHOULD_DEPLOY" == "true" ]; then
+              APPS_TO_BUILD+=("$APP_FOLDER")
+              echo "✅ Will deploy: ${APP_FOLDER}"
+            else
+              echo "⏭️  No changes in: ${APP_FOLDER}"
+            fi
+          done
+
+          # Step 4: Build the matrix JSON
           echo ""
-          if [ "$SHOULD_DEPLOY" == "true" ]; then
-            echo "✅ Changes detected - deployment will proceed"
-          else
-            echo "⏭️  No relevant changes - deployment will be skipped"
-          fi
+          echo "📦 Building deployment matrix..."
 
-  # Discover all deployable apps dynamically
-  discover:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.should-deploy == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    name: Discover deployable apps
-    outputs:
-      matrix: ${{ steps.filter.outputs.matrix }}
-      has-apps: ${{ steps.filter.outputs.has-apps }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+          MATRIX_JSON='{"include":['
+          FIRST=true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
+          for app_folder in "${APPS_TO_BUILD[@]}"; do
+            APP_PATH="apps/${app_folder}"
+            PKG_JSON="${APP_PATH}/package.json"
+            CONFIG_JSON="${APP_PATH}/cloudflare-config.json"
 
-      - name: Discover apps
-        id: discover
-        run: |
-          # Make discovery script executable
-          chmod +x .github/scripts/discover-deployable-apps.mjs
+            if [ ! -f "$PKG_JSON" ]; then
+              echo "⚠️  Warning: No package.json for ${app_folder}, skipping"
+              continue
+            fi
 
-          # Run discovery and capture output
-          MATRIX_JSON=$(node .github/scripts/discover-deployable-apps.mjs)
+            # Get package name
+            PKG_NAME=$(cat "$PKG_JSON" | grep '"name"' | head -1 | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
-          # Set outputs for next job
+            # Get config (use defaults if no config file)
+            if [ -f "$CONFIG_JSON" ]; then
+              CONFIG=$(cat "$CONFIG_JSON")
+            else
+              # Check for wrangler.jsonc as fallback
+              if [ ! -f "${APP_PATH}/wrangler.jsonc" ]; then
+                echo "⚠️  Warning: No cloudflare-config.json or wrangler.jsonc for ${app_folder}, skipping"
+                continue
+              fi
+              # Use defaults
+              CONFIG='{
+                "deployable": true,
+                "appType": "nextjs",
+                "buildCommand": "build",
+                "workerBuildCommand": "build:worker",
+                "outputDirectory": ".open-next",
+                "verifyPaths": [".open-next"],
+                "wranglerConfig": "wrangler.jsonc",
+                "wranglerEnv": "production",
+                "healthCheckPath": "/",
+                "requiresSecrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"]
+              }'
+            fi
+
+            # Check if deployable
+            DEPLOYABLE=$(echo "$CONFIG" | jq -r '.deployable // true')
+            if [ "$DEPLOYABLE" == "false" ]; then
+              echo "⏭️  Skipping ${app_folder}: deployable=false"
+              continue
+            fi
+
+            # Add to matrix
+            if [ "$FIRST" == "true" ]; then
+              FIRST=false
+            else
+              MATRIX_JSON="${MATRIX_JSON},"
+            fi
+
+            # Build matrix entry (compact JSON)
+            ENTRY=$(jq -c -n \
+              --arg name "$PKG_NAME" \
+              --arg folder "$app_folder" \
+              --argjson config "$CONFIG" \
+              '{name: $name, folder: $folder, config: $config}')
+
+            MATRIX_JSON="${MATRIX_JSON}${ENTRY}"
+          done
+
+          MATRIX_JSON="${MATRIX_JSON}]}"
+
           echo "matrix=${MATRIX_JSON}" >> $GITHUB_OUTPUT
 
           # Check if we have any apps
           APP_COUNT=$(echo "${MATRIX_JSON}" | jq '.include | length')
           if [ "$APP_COUNT" -gt 0 ]; then
             echo "has-apps=true" >> $GITHUB_OUTPUT
+            echo ""
+            echo "✅ Will deploy ${APP_COUNT} app(s)"
           else
             echo "has-apps=false" >> $GITHUB_OUTPUT
-          fi
-
-          echo "📊 Discovered ${APP_COUNT} app(s) total"
-
-      - name: Filter apps based on changes
-        id: filter
-        run: |
-          PACKAGES_CHANGED="${{ needs.detect-changes.outputs.packages-changed }}"
-          CHANGED_APPS="${{ needs.detect-changes.outputs.changed-apps }}"
-          ALL_APPS='${{ steps.discover.outputs.matrix }}'
-
-          echo "🔍 Filtering apps based on changes..."
-          echo "   Packages changed: ${PACKAGES_CHANGED}"
-          echo "   Changed apps: ${CHANGED_APPS}"
-
-          # If packages changed or manual trigger, deploy all apps
-          if [ "$PACKAGES_CHANGED" == "true" ]; then
-            echo "📦 Packages changed - deploying all apps"
-            echo "matrix=${ALL_APPS}" >> $GITHUB_OUTPUT
-            APP_COUNT=$(echo "${ALL_APPS}" | jq '.include | length')
-            if [ "$APP_COUNT" -gt 0 ]; then
-              echo "has-apps=true" >> $GITHUB_OUTPUT
-            else
-              echo "has-apps=false" >> $GITHUB_OUTPUT
-            fi
-            echo "📊 Will deploy ${APP_COUNT} app(s)"
-            exit 0
-          fi
-
-          # Filter to only changed apps
-          if [ -n "$CHANGED_APPS" ]; then
-            echo "🎯 Filtering to changed apps only..."
-
-            # Convert comma-separated list to jq filter
-            FILTER_EXPR=""
-            IFS=',' read -ra APP_ARRAY <<< "$CHANGED_APPS"
-            for app in "${APP_ARRAY[@]}"; do
-              if [ -n "$FILTER_EXPR" ]; then
-                FILTER_EXPR="${FILTER_EXPR} or"
-              fi
-              FILTER_EXPR="${FILTER_EXPR} .folder == \"${app}\""
-            done
-
-            # Filter the matrix (use -c for compact single-line JSON output)
-            FILTERED_MATRIX=$(echo "${ALL_APPS}" | jq -c '{include: [.include[] | select('"$FILTER_EXPR"')]}')
-
-            echo "matrix=${FILTERED_MATRIX}" >> $GITHUB_OUTPUT
-
-            APP_COUNT=$(echo "${FILTERED_MATRIX}" | jq '.include | length')
-            if [ "$APP_COUNT" -gt 0 ]; then
-              echo "has-apps=true" >> $GITHUB_OUTPUT
-              echo "📊 Will deploy ${APP_COUNT} app(s): ${CHANGED_APPS}"
-            else
-              echo "has-apps=false" >> $GITHUB_OUTPUT
-              echo "⏭️  No deployable apps in changed folders"
-            fi
-          else
-            echo "has-apps=false" >> $GITHUB_OUTPUT
-            echo 'matrix={"include":[]}' >> $GITHUB_OUTPUT
+            echo ""
             echo "⏭️  No apps to deploy"
           fi
 
-  # Deploy each discovered app
+  # Deploy each app
   deploy:
-    needs: discover
-    if: needs.discover.outputs.has-apps == 'true'
+    needs: prepare-deployment
+    if: needs.prepare-deployment.outputs.has-apps == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Deploy ${{ matrix.name }}
     strategy:
-      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare-deployment.outputs.matrix) }}
       fail-fast: false # Continue deploying other apps even if one fails
 
     steps:


### PR DESCRIPTION
This pull request updates the deployment system to make TanStack Router + Vite the new default app type for Cloudflare Workers deployments, replacing Next.js as the default. It also refactors the deployment workflow to simplify app discovery and matrix preparation, consolidating logic into a single job and improving clarity. Documentation is updated throughout to reflect TanStack as the default and provide clearer configuration and build instructions.

**Default App Type and Documentation Updates**
- Changed the default app type from `"nextjs"` to `"tanstack"` in deployment configuration documentation and examples, and updated supported app types to list TanStack as the default. (`.github/DEPLOYMENT.md`, `.github/README.md`) [[1]](diffhunk://#diff-bd015980eed32cbc0dedd386cf74773e3a6f635ec7aaa8e38a410f095051fadeL10-R16) [[2]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L13-R13) [[3]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L25-R33) [[4]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L77-R97)
- Updated build flow and configuration sections to show TanStack as the default, including example `package.json` and `cloudflare-config.json` for TanStack apps. (`.github/DEPLOYMENT.md`, `.github/README.md`) [[1]](diffhunk://#diff-bd015980eed32cbc0dedd386cf74773e3a6f635ec7aaa8e38a410f095051fadeR26-R50) [[2]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L60-R80)

**Deployment Workflow Refactor**
- Consolidated the app change detection and deployment matrix preparation into a single `prepare-deployment` job, removing the separate discovery and filtering steps for improved maintainability and clarity. (`.github/workflows/deploy.yml`) [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L10-R49) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L37-R228)
- Enhanced logic for selecting target apps to deploy, supporting both folder and package name references, and falling back to TanStack defaults if configuration files are missing. (`.github/workflows/deploy.yml`)

**Configuration and Build Defaults**
- Updated deployment property defaults for TanStack apps, such as `outputDirectory` now set to `"dist"`, `workerBuildCommand` set to `null`, and `verifyPaths` updated to include `"dist"` and `"cloudflare-worker.ts"`. (`.github/DEPLOYMENT.md`)

**Supported App Types**
- Clarified and reordered supported app types in documentation, listing TanStack first and marking it as the default. (`.github/README.md`)

**Build Flow Examples**
- Added explicit build flow instructions for TanStack apps, showing the Vite build and Wrangler deploy steps. (`.github/README.md`)

These changes collectively make TanStack Router + Vite the new standard for deployments and streamline the CI/CD workflow for easier maintenance and onboarding.