### PR TITLE
deploy.yml: Cloudflare deployment URL subdomain fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,13 +248,13 @@ jobs:
           echo "wrangler-env=$(echo "${CONFIG}" | jq -r '.wranglerEnv')" >> $GITHUB_OUTPUT
           echo "health-check=$(echo "${CONFIG}" | jq -r '.healthCheckPath // "/"')" >> $GITHUB_OUTPUT
 
-          # Get Cloudflare account name (use secret or default to 'apiary')
-          # Note: This is the account subdomain, not the worker name
-          ACCOUNT_NAME="${{ secrets.CF_WORKER_ACC_NAME }}"
-          if [ -z "$ACCOUNT_NAME" ]; then
-            ACCOUNT_NAME="apiary"
+          # Get Cloudflare workers.dev subdomain (use secret or default to 'apiary')
+          # This is the subdomain portion of *.workers.dev URLs (e.g., 'apiary' in apiary.workers.dev)
+          WORKER_SUBDOMAIN="${{ secrets.CF_WORKER_SUBDOMAIN }}"
+          if [ -z "$WORKER_SUBDOMAIN" ]; then
+            WORKER_SUBDOMAIN="apiary"
           fi
-          echo "account-name=${ACCOUNT_NAME}" >> $GITHUB_OUTPUT
+          echo "worker-subdomain=${WORKER_SUBDOMAIN}" >> $GITHUB_OUTPUT
 
           # Store verify paths as multiline output
           VERIFY_PATHS=$(echo "${CONFIG}" | jq -r '.verifyPaths[]?' || echo "")
@@ -695,11 +695,11 @@ jobs:
           WORKER_NAME="${{ matrix.config.workerName || matrix.folder }}"
           HEALTH_PATH="${{ steps.config.outputs.health-check }}"
           WRANGLER_ENV="${{ steps.config.outputs.wrangler-env }}"
-          ACCOUNT_NAME="${{ steps.config.outputs.account-name }}"
+          WORKER_SUBDOMAIN="${{ steps.config.outputs.worker-subdomain }}"
 
           # Construct worker URL (Cloudflare workers.dev domain)
-          # Format: https://{worker-name}-{environment}.{account-name}.workers.dev
-          WORKER_URL="https://${WORKER_NAME}-${WRANGLER_ENV}.${ACCOUNT_NAME}.workers.dev${HEALTH_PATH}"
+          # Format: https://{worker-name}-{environment}.{subdomain}.workers.dev
+          WORKER_URL="https://${WORKER_NAME}-${WRANGLER_ENV}.${WORKER_SUBDOMAIN}.workers.dev${HEALTH_PATH}"
 
           echo "📍 Checking: ${WORKER_URL}"
 
@@ -737,8 +737,8 @@ jobs:
           # Get worker name and configuration
           WORKER_NAME="${{ matrix.config.workerName || matrix.folder }}"
           WRANGLER_ENV="${{ steps.config.outputs.wrangler-env }}"
-          ACCOUNT_NAME="${{ steps.config.outputs.account-name }}"
-          DEPLOYMENT_URL="https://${WORKER_NAME}-${WRANGLER_ENV}.${ACCOUNT_NAME}.workers.dev"
+          WORKER_SUBDOMAIN="${{ steps.config.outputs.worker-subdomain }}"
+          DEPLOYMENT_URL="https://${WORKER_NAME}-${WRANGLER_ENV}.${WORKER_SUBDOMAIN}.workers.dev"
 
           if [ "${{ job.status }}" == "success" ]; then
             echo "✅ Deployment of ${{ matrix.name }} completed successfully"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,6 +248,14 @@ jobs:
           echo "wrangler-env=$(echo "${CONFIG}" | jq -r '.wranglerEnv')" >> $GITHUB_OUTPUT
           echo "health-check=$(echo "${CONFIG}" | jq -r '.healthCheckPath // "/"')" >> $GITHUB_OUTPUT
 
+          # Get Cloudflare account name (use secret or default to 'apiary')
+          # Note: This is the account subdomain, not the worker name
+          ACCOUNT_NAME="${{ secrets.CF_WORKER_ACC_NAME }}"
+          if [ -z "$ACCOUNT_NAME" ]; then
+            ACCOUNT_NAME="apiary"
+          fi
+          echo "account-name=${ACCOUNT_NAME}" >> $GITHUB_OUTPUT
+
           # Store verify paths as multiline output
           VERIFY_PATHS=$(echo "${CONFIG}" | jq -r '.verifyPaths[]?' || echo "")
           echo "verify-paths<<EOF" >> $GITHUB_OUTPUT
@@ -683,16 +691,11 @@ jobs:
         run: |
           echo "🏥 Running health check for ${{ matrix.name }}..."
 
-          # Get worker name from config
+          # Get worker name and configuration
           WORKER_NAME="${{ matrix.config.workerName || matrix.folder }}"
           HEALTH_PATH="${{ steps.config.outputs.health-check }}"
           WRANGLER_ENV="${{ steps.config.outputs.wrangler-env }}"
-
-          # Get account name (use secret or default to 'apiary')
-          ACCOUNT_NAME="${{ secrets.CF_WORKER_ACC_NAME }}"
-          if [ -z "$ACCOUNT_NAME" ]; then
-            ACCOUNT_NAME="apiary"
-          fi
+          ACCOUNT_NAME="${{ steps.config.outputs.account-name }}"
 
           # Construct worker URL (Cloudflare workers.dev domain)
           # Format: https://{worker-name}-{environment}.{account-name}.workers.dev
@@ -731,14 +734,10 @@ jobs:
       - name: Deployment summary
         if: always() && github.ref == 'refs/heads/main'
         run: |
-          # Get account name (use secret or default to 'apiary')
-          ACCOUNT_NAME="${{ secrets.CF_WORKER_ACC_NAME }}"
-          if [ -z "$ACCOUNT_NAME" ]; then
-            ACCOUNT_NAME="apiary"
-          fi
-
+          # Get worker name and configuration
           WORKER_NAME="${{ matrix.config.workerName || matrix.folder }}"
           WRANGLER_ENV="${{ steps.config.outputs.wrangler-env }}"
+          ACCOUNT_NAME="${{ steps.config.outputs.account-name }}"
           DEPLOYMENT_URL="https://${WORKER_NAME}-${WRANGLER_ENV}.${ACCOUNT_NAME}.workers.dev"
 
           if [ "${{ job.status }}" == "success" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -686,9 +686,17 @@ jobs:
           # Get worker name from config
           WORKER_NAME="${{ matrix.config.workerName || matrix.folder }}"
           HEALTH_PATH="${{ steps.config.outputs.health-check }}"
+          WRANGLER_ENV="${{ steps.config.outputs.wrangler-env }}"
+
+          # Get account name (use secret or default to 'apiary')
+          ACCOUNT_NAME="${{ secrets.CF_WORKER_ACC_NAME }}"
+          if [ -z "$ACCOUNT_NAME" ]; then
+            ACCOUNT_NAME="apiary"
+          fi
 
           # Construct worker URL (Cloudflare workers.dev domain)
-          WORKER_URL="https://${WORKER_NAME}.${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.workers.dev${HEALTH_PATH}"
+          # Format: https://{worker-name}-{environment}.{account-name}.workers.dev
+          WORKER_URL="https://${WORKER_NAME}-${WRANGLER_ENV}.${ACCOUNT_NAME}.workers.dev${HEALTH_PATH}"
 
           echo "📍 Checking: ${WORKER_URL}"
 
@@ -702,6 +710,7 @@ jobs:
           for i in $(seq 1 $MAX_RETRIES); do
             if curl -f -s -o /dev/null -w "%{http_code}" "$WORKER_URL" | grep -q "^[23]"; then
               echo "✅ Health check passed (attempt $i/$MAX_RETRIES)"
+              echo "🌐 Deployed URL: ${WORKER_URL}"
               exit 0
             else
               echo "⚠️  Health check failed (attempt $i/$MAX_RETRIES)"
@@ -714,6 +723,7 @@ jobs:
 
           echo "⚠️  Warning: Health check failed after $MAX_RETRIES attempts"
           echo "   The deployment may still be propagating. Check manually: ${WORKER_URL}"
+          echo "🌐 Deployed URL: ${WORKER_URL}"
           # Don't fail the deployment on health check failure
           exit 0
 
@@ -721,9 +731,19 @@ jobs:
       - name: Deployment summary
         if: always() && github.ref == 'refs/heads/main'
         run: |
+          # Get account name (use secret or default to 'apiary')
+          ACCOUNT_NAME="${{ secrets.CF_WORKER_ACC_NAME }}"
+          if [ -z "$ACCOUNT_NAME" ]; then
+            ACCOUNT_NAME="apiary"
+          fi
+
+          WORKER_NAME="${{ matrix.config.workerName || matrix.folder }}"
+          WRANGLER_ENV="${{ steps.config.outputs.wrangler-env }}"
+          DEPLOYMENT_URL="https://${WORKER_NAME}-${WRANGLER_ENV}.${ACCOUNT_NAME}.workers.dev"
+
           if [ "${{ job.status }}" == "success" ]; then
             echo "✅ Deployment of ${{ matrix.name }} completed successfully"
-            echo "🌐 Worker: ${{ matrix.config.workerName || matrix.folder }}"
+            echo "🌐 URL: ${DEPLOYMENT_URL}"
             echo "🔧 Type: ${{ steps.config.outputs.app-type }}"
           else
             echo "❌ Deployment of ${{ matrix.name }} failed"


### PR DESCRIPTION
This pull request updates the deployment workflow to improve the construction and reporting of deployed Cloudflare Worker URLs. The main changes ensure that the correct workers.dev subdomain is used (with support for a configurable secret), and that the deployment and health check steps consistently display the full deployed URL for easier verification and troubleshooting.

**Cloudflare Worker URL Construction and Reporting Improvements:**

* Added logic to retrieve the Cloudflare workers.dev subdomain from the `CF_WORKER_SUBDOMAIN` secret, defaulting to `'apiary'` if not set, and made it available as an output for subsequent steps.
* Updated the health check step to construct the deployed Worker URL using the worker name, environment, and subdomain, ensuring the format matches `{worker-name}-{environment}.{subdomain}.workers.dev`.
* Enhanced health check output to display the deployed URL on both success and failure, making it easier to find and verify the deployment. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R716) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R729-R745)
* Modified the deployment summary to show the full deployed URL instead of just the worker name, providing clearer feedback after deployment.