### PR TITLE
Redesign themes and fix route refresh issue

### DIFF
--- a/apps/ottabase-template-app-tanstack/cloudflare-worker.ts
+++ b/apps/ottabase-template-app-tanstack/cloudflare-worker.ts
@@ -26,6 +26,15 @@ import * as schema from "./ottabase/db/schema";
 export { RealtimeActor };
 
 function isHtmlRequest(request: Request): boolean {
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+
+  // If the path has a file extension, it's not an HTML request
+  if (/\.[a-zA-Z0-9]+$/.test(pathname)) {
+    return false;
+  }
+
+  // For routes without extensions, check the Accept header as fallback
   const accept = request.headers.get("Accept");
   return !!accept && accept.includes("text/html");
 }

--- a/apps/ottabase-template-app-tanstack/src/ottabase/config/themes/crisp.json
+++ b/apps/ottabase-template-app-tanstack/src/ottabase/config/themes/crisp.json
@@ -2,58 +2,58 @@
     "name": "crisp",
     "typography": {
         "heading": {
-            "fontFamily": "Public Sans",
-            "url": "https://fonts.googleapis.com/css2?family=Public+Sans:wght@500;600;700&display=swap"
+            "fontFamily": "Inter",
+            "url": "https://fonts.googleapis.com/css2?family=Inter:wght@600;700;800&display=swap"
         },
         "body": {
-            "fontFamily": "Public Sans",
-            "url": "https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500&display=swap"
+            "fontFamily": "Inter",
+            "url": "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
         },
         "handwriting": {
-            "fontFamily": "Patrick Hand",
-            "url": "https://fonts.googleapis.com/css2?family=Patrick+Hand&display=swap"
+            "fontFamily": "Caveat",
+            "url": "https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap"
         }
     },
-    "radius": "0.2rem",
+    "radius": "0.25rem",
     "spacing": {
-        "section": "2.5rem",
-        "card": "1.25rem",
+        "section": "2rem",
+        "card": "1rem",
         "element": "0.5rem"
     },
     "colors": {
         "light": {
             "background": "0 0% 100%",
-            "foreground": "218 54% 20%",
-            "primary": "216 100% 50%",
+            "foreground": "220 13% 20%",
+            "primary": "220 90% 48%",
             "primary-foreground": "0 0% 100%",
-            "secondary": "210 11% 96%",
-            "secondary-foreground": "218 54% 20%",
-            "muted": "210 11% 96%",
-            "muted-foreground": "218 54% 45%",
-            "accent": "210 11% 90%",
-            "accent-foreground": "218 54% 20%",
-            "destructive": "360 85% 60%",
+            "secondary": "220 14% 96%",
+            "secondary-foreground": "220 13% 25%",
+            "muted": "220 13% 91%",
+            "muted-foreground": "220 8% 45%",
+            "accent": "220 14% 96%",
+            "accent-foreground": "220 13% 25%",
+            "destructive": "0 84% 60%",
             "destructive-foreground": "0 0% 100%",
-            "border": "213 14% 88%",
-            "input": "0 0% 100%",
-            "ring": "216 100% 50%"
+            "border": "220 13% 89%",
+            "input": "220 14% 96%",
+            "ring": "220 90% 48%"
         },
         "dark": {
-            "background": "218 54% 10%",
-            "foreground": "210 11% 96%",
-            "primary": "216 100% 65%",
-            "primary-foreground": "0 0% 100%",
-            "secondary": "218 54% 15%",
-            "secondary-foreground": "210 11% 96%",
-            "muted": "218 54% 15%",
-            "muted-foreground": "216 20% 70%",
-            "accent": "218 54% 20%",
-            "accent-foreground": "210 11% 96%",
-            "destructive": "0 62% 40%",
-            "destructive-foreground": "0 0% 98%",
-            "border": "216 20% 20%",
-            "input": "218 54% 15%",
-            "ring": "216 100% 65%"
+            "background": "220 13% 9%",
+            "foreground": "220 14% 96%",
+            "primary": "220 90% 58%",
+            "primary-foreground": "220 13% 9%",
+            "secondary": "220 13% 18%",
+            "secondary-foreground": "220 14% 96%",
+            "muted": "220 13% 18%",
+            "muted-foreground": "220 10% 68%",
+            "accent": "220 13% 18%",
+            "accent-foreground": "220 14% 96%",
+            "destructive": "0 84% 60%",
+            "destructive-foreground": "220 13% 9%",
+            "border": "220 13% 18%",
+            "input": "220 13% 18%",
+            "ring": "220 90% 58%"
         }
     }
 }

--- a/apps/ottabase-template-app-tanstack/src/ottabase/config/themes/neo.json
+++ b/apps/ottabase-template-app-tanstack/src/ottabase/config/themes/neo.json
@@ -2,58 +2,58 @@
     "name": "neo",
     "typography": {
         "heading": {
-            "fontFamily": "Outfit",
-            "url": "https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap"
+            "fontFamily": "Inter",
+            "url": "https://fonts.googleapis.com/css2?family=Inter:wght@500;600;700;800&display=swap"
         },
         "body": {
             "fontFamily": "Inter",
             "url": "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
         },
         "handwriting": {
-            "fontFamily": "Pacifico",
-            "url": "https://fonts.googleapis.com/css2?family=Pacifico&display=swap"
+            "fontFamily": "Caveat",
+            "url": "https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap"
         }
     },
-    "radius": "0rem",
+    "radius": "0.375rem",
     "spacing": {
-        "section": "4rem",
-        "card": "2.5rem",
-        "element": "1rem"
+        "section": "2.5rem",
+        "card": "1.5rem",
+        "element": "0.75rem"
     },
     "colors": {
         "light": {
             "background": "0 0% 100%",
-            "foreground": "0 0% 0%",
-            "primary": "262 83% 58%",
+            "foreground": "210 11% 15%",
+            "primary": "211 100% 50%",
             "primary-foreground": "0 0% 100%",
-            "secondary": "262 30% 95%",
-            "secondary-foreground": "262 83% 58%",
-            "muted": "240 5% 96%",
-            "muted-foreground": "240 4% 46%",
-            "accent": "262 30% 95%",
-            "accent-foreground": "262 83% 58%",
+            "secondary": "210 14% 97%",
+            "secondary-foreground": "210 11% 20%",
+            "muted": "210 11% 92%",
+            "muted-foreground": "210 8% 40%",
+            "accent": "210 14% 97%",
+            "accent-foreground": "210 11% 20%",
             "destructive": "0 84% 60%",
             "destructive-foreground": "0 0% 100%",
-            "border": "240 6% 90%",
-            "input": "240 6% 90%",
-            "ring": "262 83% 58%"
+            "border": "210 13% 91%",
+            "input": "210 14% 97%",
+            "ring": "211 100% 50%"
         },
         "dark": {
-            "background": "240 10% 4%",
-            "foreground": "0 0% 98%",
-            "primary": "262 83% 65%",
-            "primary-foreground": "0 0% 100%",
-            "secondary": "240 4% 16%",
-            "secondary-foreground": "0 0% 98%",
-            "muted": "240 4% 16%",
-            "muted-foreground": "240 5% 65%",
-            "accent": "240 4% 16%",
-            "accent-foreground": "0 0% 98%",
-            "destructive": "0 62% 30%",
-            "destructive-foreground": "0 0% 98%",
-            "border": "240 4% 16%",
-            "input": "240 4% 16%",
-            "ring": "262 83% 65%"
+            "background": "210 11% 10%",
+            "foreground": "210 14% 97%",
+            "primary": "211 100% 60%",
+            "primary-foreground": "210 11% 10%",
+            "secondary": "210 11% 20%",
+            "secondary-foreground": "210 14% 97%",
+            "muted": "210 11% 20%",
+            "muted-foreground": "210 8% 70%",
+            "accent": "210 11% 20%",
+            "accent-foreground": "210 14% 97%",
+            "destructive": "0 84% 60%",
+            "destructive-foreground": "210 11% 10%",
+            "border": "210 11% 20%",
+            "input": "210 11% 20%",
+            "ring": "211 100% 60%"
         }
     }
 }


### PR DESCRIPTION
- Redesign Neo theme to modern, minimal aesthetic with:
  - Clean blue-based color palette inspired by GitHub
  - Softer rounded corners (0.375rem)
  - Improved spacing and hierarchy
  - Inter fonts for consistency

- Redesign Crisp theme to minimal style with:
  - Minimal blue color palette inspired by Notion
  - Subtle rounded corners (0.25rem)
  - Compact spacing
  - Clean Inter fonts

- Fix routing issue where routes don't persist on page refresh by:
  - Improving SPA fallback logic in Cloudflare Worker
  - Checking file extensions to detect routes vs static assets
  - More robust path-based routing detection