### PR TITLE
deploy.yml: Fix cleanup preview worker job - add pnpm setup

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -497,6 +497,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.15.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Determine worker subdomain
         id: cleanup-config
         run: |


### PR DESCRIPTION
The cleanup-preview job was failing because it was trying to use the wrangler-action without having pnpm installed. The action depends on pnpm to install wrangler. This commit adds the missing Setup pnpm and Setup Node.js steps to the cleanup-preview job, matching the setup in other jobs.

Fixes: Preview worker cleanup failing with "Unable to locate executable
file: pnpm" error
