### PR TITLE
Fix cleanup preview worker - use npm instead of pnpm

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -497,11 +497,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10.15.1
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
The cleanup job only needs to delete a worker and doesn't require the full monorepo dependencies. Removed pnpm setup so the wrangler-action can use npm instead, which is simpler and faster.

This fixes the 'The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1' error that occurred when pnpm tried to install monorepo dependencies.