### PR TITLE
Fix cleanup preview worker - install wrangler with npm directly

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -554,11 +554,12 @@ jobs:
           echo "preview-name=${BASE_NAME}-pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
       - name: Delete preview worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: delete ${{ steps.cleanup-name.outputs.preview-name }}
+        run: |
+          npm install -g wrangler
+          wrangler delete ${{ steps.cleanup-name.outputs.preview-name }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         continue-on-error: true
 
       - name: Cleanup summary


### PR DESCRIPTION
Instead of using cloudflare/wrangler-action@v3 which auto-detects pnpm-lock.yaml and tries to use pnpm, install wrangler globally via npm and call it directly. This completely avoids the pnpm auto-detection issue.

Credentials are passed via environment variables which wrangler reads natively.
