### PR TITLE
feat: add notifications package

### DIFF
--- a/apps/ottabase-template-app-tanstack/src/pages/admin/AdminIndexPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/AdminIndexPage.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@otta
 import { Link } from '@tanstack/react-router';
 import {
     Activity,
+    Bell,
     Building2,
     Clock,
     Database,
@@ -114,6 +115,13 @@ export function AdminIndexPage() {
             description: 'Manage DB-driven cron jobs, view run history, and schedule new tasks.',
             href: '/admin/cron',
             icon: Clock,
+            disabled: false,
+        },
+        {
+            title: 'Notifications',
+            description: 'Send notifications to users and broadcast system alerts to administrators.',
+            href: '/admin/notifications',
+            icon: Bell,
             disabled: false,
         },
         {

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/AdminNotificationsPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/AdminNotificationsPage.tsx
@@ -1,0 +1,429 @@
+import { useState } from 'react';
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+    Textarea,
+    Badge,
+} from '@ottabase/ui-shadcn';
+import { Bell, Mail, Radio, Send, AlertCircle, CheckCircle2, Clock } from 'lucide-react';
+
+interface NotificationForm {
+    recipientId: string;
+    recipientEmail: string;
+    title: string;
+    message: string;
+    channel: 'email' | 'websocket' | 'system';
+    priority: 'low' | 'normal' | 'high' | 'urgent';
+    category?: string;
+    actionUrl?: string;
+    actionText?: string;
+}
+
+export function AdminNotificationsPage() {
+    const [form, setForm] = useState<NotificationForm>({
+        recipientId: '',
+        recipientEmail: '',
+        title: '',
+        message: '',
+        channel: 'email',
+        priority: 'normal',
+    });
+
+    const [sending, setSending] = useState(false);
+    const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
+
+    const handleSend = async () => {
+        setSending(true);
+        setResult(null);
+
+        try {
+            // TODO: Implement actual API call to send notification
+            const response = await fetch('/api/admin/notifications/send', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(form),
+            });
+
+            if (response.ok) {
+                setResult({ success: true, message: 'Notification sent successfully!' });
+                // Reset form
+                setForm({
+                    recipientId: '',
+                    recipientEmail: '',
+                    title: '',
+                    message: '',
+                    channel: 'email',
+                    priority: 'normal',
+                });
+            } else {
+                const error = await response.json();
+                setResult({ success: false, message: error.message || 'Failed to send notification' });
+            }
+        } catch (error) {
+            setResult({ success: false, message: 'Error sending notification' });
+        } finally {
+            setSending(false);
+        }
+    };
+
+    const sendSystemAlert = async (severity: 'info' | 'warning' | 'error' | 'critical') => {
+        setSending(true);
+        try {
+            await fetch('/api/admin/notifications/system-alert', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    title: form.title,
+                    message: form.message,
+                    severity,
+                    eventType: 'admin.manual',
+                }),
+            });
+            setResult({ success: true, message: 'System alert sent to admins!' });
+        } catch (error) {
+            setResult({ success: false, message: 'Failed to send system alert' });
+        } finally {
+            setSending(false);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+                    <Bell className="h-8 w-8" />
+                    Notifications Management
+                </h1>
+                <p className="text-muted-foreground mt-2">
+                    Send notifications to users or broadcast system alerts to administrators.
+                </p>
+            </div>
+
+            <Tabs defaultValue="send" className="w-full">
+                <TabsList className="grid w-full grid-cols-3">
+                    <TabsTrigger value="send">Send Notification</TabsTrigger>
+                    <TabsTrigger value="system">System Alerts</TabsTrigger>
+                    <TabsTrigger value="history">Notification History</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="send" className="space-y-4">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Send Notification to User</CardTitle>
+                            <CardDescription>
+                                Choose a channel (email, websocket, or system) and compose your notification
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="recipientId">Recipient User ID</Label>
+                                    <Input
+                                        id="recipientId"
+                                        placeholder="user-123"
+                                        value={form.recipientId}
+                                        onChange={(e) => setForm({ ...form, recipientId: e.target.value })}
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="recipientEmail">Recipient Email</Label>
+                                    <Input
+                                        id="recipientEmail"
+                                        type="email"
+                                        placeholder="user@example.com"
+                                        value={form.recipientEmail}
+                                        onChange={(e) => setForm({ ...form, recipientEmail: e.target.value })}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="channel">Channel</Label>
+                                    <Select
+                                        value={form.channel}
+                                        onValueChange={(value: any) => setForm({ ...form, channel: value })}
+                                    >
+                                        <SelectTrigger id="channel">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="email">
+                                                <div className="flex items-center gap-2">
+                                                    <Mail className="h-4 w-4" />
+                                                    Email
+                                                </div>
+                                            </SelectItem>
+                                            <SelectItem value="websocket">
+                                                <div className="flex items-center gap-2">
+                                                    <Radio className="h-4 w-4" />
+                                                    WebSocket
+                                                </div>
+                                            </SelectItem>
+                                            <SelectItem value="system">
+                                                <div className="flex items-center gap-2">
+                                                    <AlertCircle className="h-4 w-4" />
+                                                    System
+                                                </div>
+                                            </SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="priority">Priority</Label>
+                                    <Select
+                                        value={form.priority}
+                                        onValueChange={(value: any) => setForm({ ...form, priority: value })}
+                                    >
+                                        <SelectTrigger id="priority">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="low">Low</SelectItem>
+                                            <SelectItem value="normal">Normal</SelectItem>
+                                            <SelectItem value="high">High</SelectItem>
+                                            <SelectItem value="urgent">Urgent</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="category">Category (Optional)</Label>
+                                    <Input
+                                        id="category"
+                                        placeholder="e.g. security, update"
+                                        value={form.category || ''}
+                                        onChange={(e) => setForm({ ...form, category: e.target.value })}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="title">Title</Label>
+                                <Input
+                                    id="title"
+                                    placeholder="Notification title"
+                                    value={form.title}
+                                    onChange={(e) => setForm({ ...form, title: e.target.value })}
+                                />
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="message">Message</Label>
+                                <Textarea
+                                    id="message"
+                                    placeholder="Notification message content"
+                                    value={form.message}
+                                    onChange={(e) => setForm({ ...form, message: e.target.value })}
+                                    rows={4}
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="actionUrl">Action URL (Optional)</Label>
+                                    <Input
+                                        id="actionUrl"
+                                        placeholder="https://example.com/action"
+                                        value={form.actionUrl || ''}
+                                        onChange={(e) => setForm({ ...form, actionUrl: e.target.value })}
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="actionText">Action Button Text</Label>
+                                    <Input
+                                        id="actionText"
+                                        placeholder="View Details"
+                                        value={form.actionText || ''}
+                                        onChange={(e) => setForm({ ...form, actionText: e.target.value })}
+                                    />
+                                </div>
+                            </div>
+
+                            {result && (
+                                <div
+                                    className={`p-4 rounded-lg flex items-center gap-2 ${
+                                        result.success ? 'bg-green-50 text-green-900' : 'bg-red-50 text-red-900'
+                                    }`}
+                                >
+                                    {result.success ? (
+                                        <CheckCircle2 className="h-5 w-5" />
+                                    ) : (
+                                        <AlertCircle className="h-5 w-5" />
+                                    )}
+                                    {result.message}
+                                </div>
+                            )}
+
+                            <Button
+                                onClick={handleSend}
+                                disabled={sending || !form.title || !form.message}
+                                className="w-full"
+                            >
+                                <Send className="mr-2 h-4 w-4" />
+                                {sending ? 'Sending...' : 'Send Notification'}
+                            </Button>
+                        </CardContent>
+                    </Card>
+                </TabsContent>
+
+                <TabsContent value="system" className="space-y-4">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Broadcast System Alert</CardTitle>
+                            <CardDescription>
+                                Send alerts to all administrators about system events or issues
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="system-title">Alert Title</Label>
+                                <Input
+                                    id="system-title"
+                                    placeholder="System alert title"
+                                    value={form.title}
+                                    onChange={(e) => setForm({ ...form, title: e.target.value })}
+                                />
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="system-message">Alert Message</Label>
+                                <Textarea
+                                    id="system-message"
+                                    placeholder="Describe the system event or issue"
+                                    value={form.message}
+                                    onChange={(e) => setForm({ ...form, message: e.target.value })}
+                                    rows={4}
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4">
+                                <Button
+                                    variant="outline"
+                                    onClick={() => sendSystemAlert('info')}
+                                    disabled={sending || !form.title || !form.message}
+                                >
+                                    <Badge className="mr-2 bg-blue-500">Info</Badge>
+                                    Send Info Alert
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => sendSystemAlert('warning')}
+                                    disabled={sending || !form.title || !form.message}
+                                >
+                                    <Badge className="mr-2 bg-yellow-500">Warning</Badge>
+                                    Send Warning
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => sendSystemAlert('error')}
+                                    disabled={sending || !form.title || !form.message}
+                                >
+                                    <Badge className="mr-2 bg-orange-500">Error</Badge>
+                                    Send Error Alert
+                                </Button>
+                                <Button
+                                    variant="destructive"
+                                    onClick={() => sendSystemAlert('critical')}
+                                    disabled={sending || !form.title || !form.message}
+                                >
+                                    <Badge className="mr-2 bg-red-500">Critical</Badge>
+                                    Send Critical Alert
+                                </Button>
+                            </div>
+
+                            {result && (
+                                <div
+                                    className={`p-4 rounded-lg flex items-center gap-2 ${
+                                        result.success ? 'bg-green-50 text-green-900' : 'bg-red-50 text-red-900'
+                                    }`}
+                                >
+                                    {result.success ? (
+                                        <CheckCircle2 className="h-5 w-5" />
+                                    ) : (
+                                        <AlertCircle className="h-5 w-5" />
+                                    )}
+                                    {result.message}
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
+                </TabsContent>
+
+                <TabsContent value="history" className="space-y-4">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Notification History</CardTitle>
+                            <CardDescription>View recently sent notifications and their status</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="space-y-4">
+                                <div className="rounded-lg border p-4">
+                                    <div className="flex items-center justify-between">
+                                        <div>
+                                            <h4 className="font-medium">Sample Notification</h4>
+                                            <p className="text-sm text-muted-foreground">
+                                                Sent to user@example.com via email
+                                            </p>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <Badge variant="outline">
+                                                <CheckCircle2 className="mr-1 h-3 w-3" />
+                                                Sent
+                                            </Badge>
+                                            <Clock className="h-4 w-4 text-muted-foreground" />
+                                            <span className="text-sm text-muted-foreground">2 hours ago</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <p className="text-center text-sm text-muted-foreground">
+                                    Connect to your notification database to view real history
+                                </p>
+                            </div>
+                        </CardContent>
+                    </Card>
+                </TabsContent>
+            </Tabs>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Quick Stats</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <div className="grid grid-cols-4 gap-4">
+                        <div className="text-center">
+                            <div className="text-2xl font-bold">0</div>
+                            <div className="text-sm text-muted-foreground">Sent Today</div>
+                        </div>
+                        <div className="text-center">
+                            <div className="text-2xl font-bold">0</div>
+                            <div className="text-sm text-muted-foreground">Pending</div>
+                        </div>
+                        <div className="text-center">
+                            <div className="text-2xl font-bold">0</div>
+                            <div className="text-sm text-muted-foreground">Failed</div>
+                        </div>
+                        <div className="text-center">
+                            <div className="text-2xl font-bold">0</div>
+                            <div className="text-sm text-muted-foreground">Read Rate</div>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/apps/ottabase-template-app-tanstack/src/pages/demo/DemoIndexPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/demo/DemoIndexPage.tsx
@@ -189,6 +189,21 @@ export function DemoIndexPage() {
                         </Button>
                     </CardContent>
                 </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Notifications</CardTitle>
+                        <CardDescription>
+                            Multi-channel notification system with email, WebSocket, and system alerts via
+                            @ottabase/notifications
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <Button asChild variant="outline" className="w-full">
+                            <Link to="/demo/notifications">View Notifications Demo</Link>
+                        </Button>
+                    </CardContent>
+                </Card>
             </div>
 
             <div className="mt-2 rounded-lg border bg-muted/50 p-6">

--- a/apps/ottabase-template-app-tanstack/src/pages/demo/notifications/DemoNotificationsPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/demo/notifications/DemoNotificationsPage.tsx
@@ -1,0 +1,449 @@
+import { useState } from 'react';
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Badge,
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@ottabase/ui-shadcn';
+import { Bell, Mail, Radio, AlertCircle, CheckCircle2, Clock, Inbox, Archive } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+
+interface DemoNotification {
+    id: string;
+    title: string;
+    message: string;
+    channel: 'email' | 'websocket' | 'system';
+    priority: 'low' | 'normal' | 'high' | 'urgent';
+    status: 'pending' | 'sent' | 'read';
+    timestamp: string;
+    actionUrl?: string;
+    actionText?: string;
+}
+
+export function DemoNotificationsPage() {
+    const [notifications, setNotifications] = useState<DemoNotification[]>([
+        {
+            id: '1',
+            title: 'Welcome to Ottabase!',
+            message: 'Thanks for trying out our notification system. This is a demo email notification.',
+            channel: 'email',
+            priority: 'normal',
+            status: 'sent',
+            timestamp: '2 hours ago',
+            actionUrl: '/demo',
+            actionText: 'Explore Demos',
+        },
+        {
+            id: '2',
+            title: 'Real-time Update',
+            message: 'This notification was delivered via WebSocket for instant updates.',
+            channel: 'websocket',
+            priority: 'high',
+            status: 'read',
+            timestamp: '1 hour ago',
+        },
+        {
+            id: '3',
+            title: 'System Alert',
+            message: 'A critical system notification for administrators.',
+            channel: 'system',
+            priority: 'urgent',
+            status: 'sent',
+            timestamp: '30 minutes ago',
+        },
+    ]);
+
+    const [stats] = useState({
+        total: 127,
+        unread: 5,
+        sent: 120,
+        failed: 2,
+    });
+
+    const sendTestNotification = async (channel: 'email' | 'websocket' | 'system') => {
+        const newNotification: DemoNotification = {
+            id: Date.now().toString(),
+            title: `Test ${channel} Notification`,
+            message: `This is a test notification sent via ${channel}`,
+            channel,
+            priority: 'normal',
+            status: 'sent',
+            timestamp: 'just now',
+        };
+
+        setNotifications([newNotification, ...notifications]);
+    };
+
+    const markAsRead = (id: string) => {
+        setNotifications(notifications.map((n) => (n.id === id ? { ...n, status: 'read' as const } : n)));
+    };
+
+    const getPriorityColor = (priority: string) => {
+        switch (priority) {
+            case 'urgent':
+                return 'bg-red-500';
+            case 'high':
+                return 'bg-orange-500';
+            case 'normal':
+                return 'bg-blue-500';
+            case 'low':
+                return 'bg-gray-500';
+            default:
+                return 'bg-blue-500';
+        }
+    };
+
+    const getChannelIcon = (channel: string) => {
+        switch (channel) {
+            case 'email':
+                return <Mail className="h-4 w-4" />;
+            case 'websocket':
+                return <Radio className="h-4 w-4" />;
+            case 'system':
+                return <AlertCircle className="h-4 w-4" />;
+            default:
+                return <Bell className="h-4 w-4" />;
+        }
+    };
+
+    return (
+        <div className="space-y-6 p-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <Button asChild variant="ghost" className="mb-4">
+                        <Link to="/demo">← Back to Demos</Link>
+                    </Button>
+                    <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+                        <Bell className="h-8 w-8" />
+                        Notifications Demo
+                    </h1>
+                    <p className="text-muted-foreground mt-2">
+                        Multi-channel notification system with email, WebSocket, and system alerts
+                    </p>
+                </div>
+            </div>
+
+            {/* Stats Cards */}
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <Card>
+                    <CardContent className="p-6">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-sm font-medium text-muted-foreground">Total Sent</p>
+                                <p className="text-2xl font-bold">{stats.total}</p>
+                            </div>
+                            <Bell className="h-8 w-8 text-muted-foreground" />
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-6">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-sm font-medium text-muted-foreground">Unread</p>
+                                <p className="text-2xl font-bold">{stats.unread}</p>
+                            </div>
+                            <Inbox className="h-8 w-8 text-blue-500" />
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-6">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-sm font-medium text-muted-foreground">Delivered</p>
+                                <p className="text-2xl font-bold">{stats.sent}</p>
+                            </div>
+                            <CheckCircle2 className="h-8 w-8 text-green-500" />
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-6">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-sm font-medium text-muted-foreground">Failed</p>
+                                <p className="text-2xl font-bold">{stats.failed}</p>
+                            </div>
+                            <AlertCircle className="h-8 w-8 text-red-500" />
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {/* Features */}
+                <div className="md:col-span-1 space-y-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Features</CardTitle>
+                            <CardDescription>Test different notification channels</CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div>
+                                <h4 className="font-medium mb-2">Multi-Channel Support</h4>
+                                <div className="space-y-2">
+                                    <Button
+                                        variant="outline"
+                                        className="w-full justify-start"
+                                        onClick={() => sendTestNotification('email')}
+                                    >
+                                        <Mail className="mr-2 h-4 w-4" />
+                                        Send Email Notification
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        className="w-full justify-start"
+                                        onClick={() => sendTestNotification('websocket')}
+                                    >
+                                        <Radio className="mr-2 h-4 w-4" />
+                                        Send WebSocket Notification
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        className="w-full justify-start"
+                                        onClick={() => sendTestNotification('system')}
+                                    >
+                                        <AlertCircle className="mr-2 h-4 w-4" />
+                                        Send System Alert
+                                    </Button>
+                                </div>
+                            </div>
+
+                            <div>
+                                <h4 className="font-medium mb-2">Priority Levels</h4>
+                                <div className="space-y-2">
+                                    <div className="flex items-center gap-2">
+                                        <Badge className="bg-red-500">Urgent</Badge>
+                                        <span className="text-sm">Critical notifications</span>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Badge className="bg-orange-500">High</Badge>
+                                        <span className="text-sm">Important updates</span>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Badge className="bg-blue-500">Normal</Badge>
+                                        <span className="text-sm">Standard messages</span>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Badge className="bg-gray-500">Low</Badge>
+                                        <span className="text-sm">Informational</span>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <h4 className="font-medium mb-2">Capabilities</h4>
+                                <ul className="text-sm space-y-1 text-muted-foreground">
+                                    <li>✓ Email delivery via multiple providers</li>
+                                    <li>✓ Real-time WebSocket notifications</li>
+                                    <li>✓ System alerts for admins</li>
+                                    <li>✓ Async queue processing</li>
+                                    <li>✓ User preferences</li>
+                                    <li>✓ Status tracking</li>
+                                    <li>✓ Action buttons & URLs</li>
+                                </ul>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Integration</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="space-y-2 text-sm">
+                                <p className="font-medium">Packages Used:</p>
+                                <ul className="text-muted-foreground space-y-1">
+                                    <li>• @ottabase/notifications</li>
+                                    <li>• @ottabase/email</li>
+                                    <li>• @ottabase/cf-realtime</li>
+                                    <li>• @ottabase/queue</li>
+                                </ul>
+                            </div>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                {/* Notification Feed */}
+                <div className="md:col-span-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Notification Feed</CardTitle>
+                            <CardDescription>Recent notifications across all channels</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <Tabs defaultValue="all">
+                                <TabsList className="grid w-full grid-cols-4">
+                                    <TabsTrigger value="all">
+                                        All <Badge className="ml-2">{notifications.length}</Badge>
+                                    </TabsTrigger>
+                                    <TabsTrigger value="email">
+                                        Email{' '}
+                                        <Badge className="ml-2">
+                                            {notifications.filter((n) => n.channel === 'email').length}
+                                        </Badge>
+                                    </TabsTrigger>
+                                    <TabsTrigger value="websocket">
+                                        WebSocket{' '}
+                                        <Badge className="ml-2">
+                                            {notifications.filter((n) => n.channel === 'websocket').length}
+                                        </Badge>
+                                    </TabsTrigger>
+                                    <TabsTrigger value="system">
+                                        System{' '}
+                                        <Badge className="ml-2">
+                                            {notifications.filter((n) => n.channel === 'system').length}
+                                        </Badge>
+                                    </TabsTrigger>
+                                </TabsList>
+
+                                <TabsContent value="all" className="space-y-4 mt-4">
+                                    {notifications.length === 0 ? (
+                                        <div className="text-center py-12 text-muted-foreground">
+                                            <Archive className="h-12 w-12 mx-auto mb-4" />
+                                            <p>No notifications yet. Try sending a test notification!</p>
+                                        </div>
+                                    ) : (
+                                        notifications.map((notification) => (
+                                            <div
+                                                key={notification.id}
+                                                className="border rounded-lg p-4 hover:bg-muted/50 transition-colors"
+                                            >
+                                                <div className="flex items-start justify-between">
+                                                    <div className="flex-1">
+                                                        <div className="flex items-center gap-2 mb-2">
+                                                            {getChannelIcon(notification.channel)}
+                                                            <h4 className="font-medium">{notification.title}</h4>
+                                                            <Badge className={getPriorityColor(notification.priority)}>
+                                                                {notification.priority}
+                                                            </Badge>
+                                                            {notification.status === 'read' ? (
+                                                                <Badge variant="outline">Read</Badge>
+                                                            ) : (
+                                                                <Badge variant="default">New</Badge>
+                                                            )}
+                                                        </div>
+                                                        <p className="text-sm text-muted-foreground mb-2">
+                                                            {notification.message}
+                                                        </p>
+                                                        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                                                            <span className="flex items-center gap-1">
+                                                                <Clock className="h-3 w-3" />
+                                                                {notification.timestamp}
+                                                            </span>
+                                                            <span>via {notification.channel}</span>
+                                                        </div>
+                                                    </div>
+                                                    <div className="flex gap-2">
+                                                        {notification.status !== 'read' && (
+                                                            <Button
+                                                                size="sm"
+                                                                variant="outline"
+                                                                onClick={() => markAsRead(notification.id)}
+                                                            >
+                                                                Mark as Read
+                                                            </Button>
+                                                        )}
+                                                        {notification.actionUrl && (
+                                                            <Button size="sm">
+                                                                {notification.actionText || 'View'}
+                                                            </Button>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ))
+                                    )}
+                                </TabsContent>
+
+                                <TabsContent value="email" className="space-y-4 mt-4">
+                                    {notifications
+                                        .filter((n) => n.channel === 'email')
+                                        .map((notification) => (
+                                            <div key={notification.id} className="border rounded-lg p-4">
+                                                <h4 className="font-medium mb-2">{notification.title}</h4>
+                                                <p className="text-sm text-muted-foreground">{notification.message}</p>
+                                            </div>
+                                        ))}
+                                </TabsContent>
+
+                                <TabsContent value="websocket" className="space-y-4 mt-4">
+                                    {notifications
+                                        .filter((n) => n.channel === 'websocket')
+                                        .map((notification) => (
+                                            <div key={notification.id} className="border rounded-lg p-4">
+                                                <h4 className="font-medium mb-2">{notification.title}</h4>
+                                                <p className="text-sm text-muted-foreground">{notification.message}</p>
+                                            </div>
+                                        ))}
+                                </TabsContent>
+
+                                <TabsContent value="system" className="space-y-4 mt-4">
+                                    {notifications
+                                        .filter((n) => n.channel === 'system')
+                                        .map((notification) => (
+                                            <div
+                                                key={notification.id}
+                                                className="border rounded-lg p-4 border-red-200 bg-red-50/50"
+                                            >
+                                                <h4 className="font-medium mb-2">{notification.title}</h4>
+                                                <p className="text-sm text-muted-foreground">{notification.message}</p>
+                                            </div>
+                                        ))}
+                                </TabsContent>
+                            </Tabs>
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+
+            {/* Code Example */}
+            <Card>
+                <CardHeader>
+                    <CardTitle>Usage Example</CardTitle>
+                    <CardDescription>How to use @ottabase/notifications in your application</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm">
+                        <code>{`import { NotificationManager, createEmailChannel } from '@ottabase/notifications';
+
+// Setup notification manager
+const manager = new NotificationManager({
+  defaultChannels: ['email', 'websocket'],
+  email: { from: 'noreply@example.com' }
+});
+
+// Register channels
+manager.registerChannel(emailChannel);
+manager.registerChannel(wsChannel);
+
+// Send notification
+await manager.notify({
+  recipient: {
+    userId: '123',
+    email: 'user@example.com'
+  },
+  payload: {
+    title: 'Welcome!',
+    message: 'Thanks for signing up',
+    actionUrl: '/dashboard',
+    actionText: 'Go to Dashboard'
+  },
+  options: {
+    priority: 'high'
+  }
+});`}</code>
+                    </pre>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/apps/ottabase-template-app-tanstack/src/router.tsx
+++ b/apps/ottabase-template-app-tanstack/src/router.tsx
@@ -325,6 +325,16 @@ const demoEmailRoute = new Route({
     ),
 });
 
+const demoNotificationsRoute = new Route({
+    getParentRoute: () => demoLayoutRoute,
+    path: 'notifications',
+    component: lazyRouteComponent(() =>
+        import('@/pages/demo/notifications/DemoNotificationsPage').then((m) => ({
+            default: m.DemoNotificationsPage,
+        })),
+    ),
+});
+
 const demoLoggerRoute = new Route({
     getParentRoute: () => demoLayoutRoute,
     path: 'logger',
@@ -489,6 +499,17 @@ const adminCronRoute = new Route({
     component: lazyRouteComponent(() =>
         import('@/pages/admin/AdminCronPage').then((m) => ({
             default: m.AdminCronPage,
+        })),
+    ),
+});
+
+// Admin Notifications route
+const adminNotificationsRoute = new Route({
+    getParentRoute: () => rootRoute,
+    path: '/admin/notifications',
+    component: lazyRouteComponent(() =>
+        import('@/pages/admin/AdminNotificationsPage').then((m) => ({
+            default: m.AdminNotificationsPage,
         })),
     ),
 });
@@ -752,6 +773,7 @@ demoLayoutRoute.addChildren([
     demoStateRoute,
     demoRendererRoute,
     demoEmailRoute,
+    demoNotificationsRoute,
 ]);
 
 const routeTree = rootRoute.addChildren([
@@ -770,6 +792,7 @@ const routeTree = rootRoute.addChildren([
     adminReferralsRoute,
     adminQueueRoute,
     adminCronRoute,
+    adminNotificationsRoute,
     adminBlogRoute,
     adminBlogNewRoute,
     adminBlogEditRoute,

--- a/packages/i18n/src/__tests__/react.test.tsx
+++ b/packages/i18n/src/__tests__/react.test.tsx
@@ -174,10 +174,13 @@ describe('React Integration', () => {
                 screen.getByTestId('switch-btn').click();
             });
 
-            // Should update to Spanish
-            await waitFor(() => {
-                expect(screen.getByTestId('greeting')).toHaveTextContent('Bienvenido a Ottabase');
-            });
+            // Should update to Spanish (allow a bit more time for async language change)
+            await waitFor(
+                () => {
+                    expect(screen.getByTestId('greeting')).toHaveTextContent('Bienvenido a Ottabase');
+                },
+                { timeout: 3000 },
+            );
         });
 
         it('should support interpolation', async () => {

--- a/packages/notifications/.eslintrc.json
+++ b/packages/notifications/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    }
+}

--- a/packages/notifications/.gitignore
+++ b/packages/notifications/.gitignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+*.log
+.turbo
+coverage
+.DS_Store

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -199,16 +199,16 @@ const enabled = prefs.isCategoryEnabled('security'); // true
 ### Notification Model
 
 ```typescript
-import { Notification } from '@ottabase/notifications/models';
+import { NotificationModel } from '@ottabase/notifications/models';
 
 // Find user's notifications
-const notifications = await Notification.find({ userId: '123' });
+const notifications = await NotificationModel.find({ userId: '123' });
 
 // Get unread notifications
-const unread = await Notification.getUnread('123');
+const unread = await NotificationModel.getUnread('123');
 
 // Get by category
-const security = await Notification.getByCategory('123', 'security');
+const security = await NotificationModel.getByCategory('123', 'security');
 
 // Mark as read
 await notification.markAsRead();

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -1,0 +1,359 @@
+# @ottabase/notifications
+
+Minimalistic notifications engine for Ottabase - multi-channel user notifications, system alerts, and real-time updates.
+
+## Features
+
+- 📧 **Email Notifications** - Via `@ottabase/email` with multiple provider support
+- 🔔 **Real-time WebSocket** - Via `@ottabase/cf-realtime` for instant updates
+- 🚨 **System Alerts** - Admin notifications for critical events
+- ⚡ **Async Processing** - Queue-based delivery via `@ottabase/queue`
+- 👤 **User Preferences** - Customizable notification settings per user
+- 💾 **Persistence** - OttaORM models for notification storage
+- 🎯 **Priority Levels** - Low, normal, high, urgent
+- 📊 **Tracking** - Status tracking (pending, sent, failed, read)
+
+## Installation
+
+```bash
+pnpm add @ottabase/notifications
+```
+
+## Quick Start
+
+```typescript
+import { NotificationManager, createEmailChannel, createWebSocketChannel } from '@ottabase/notifications';
+import { createResendMailer } from '@ottabase/email/providers/resend';
+import { RealtimeBroadcaster } from '@ottabase/cf-realtime/server';
+
+// Create channels
+const emailChannel = createEmailChannel({
+    mailer: createResendMailer({ apiKey: env.RESEND_API_KEY }),
+    from: 'noreply@example.com',
+});
+
+const wsChannel = createWebSocketChannel({
+    broadcaster: new RealtimeBroadcaster(env),
+});
+
+// Create manager
+const manager = new NotificationManager({
+    defaultChannels: ['email', 'websocket'],
+    email: { from: 'noreply@example.com' },
+});
+
+// Register channels
+manager.registerChannel(emailChannel);
+manager.registerChannel(wsChannel);
+
+// Send notification
+await manager.notify({
+    recipient: {
+        userId: '123',
+        email: 'user@example.com',
+    },
+    payload: {
+        title: 'Welcome to Ottabase!',
+        message: 'Thanks for signing up. Get started by exploring our features.',
+        actionUrl: 'https://example.com/dashboard',
+        actionText: 'Go to Dashboard',
+        category: 'welcome',
+    },
+    options: {
+        priority: 'high',
+    },
+});
+```
+
+## Channels
+
+### Email Channel
+
+```typescript
+import { createEmailChannel } from '@ottabase/notifications/channels';
+import { createResendMailer } from '@ottabase/email/providers/resend';
+
+const emailChannel = createEmailChannel({
+    mailer: createResendMailer({ apiKey: env.RESEND_API_KEY }),
+    from: 'noreply@example.com',
+    replyTo: 'support@example.com',
+});
+
+manager.registerChannel(emailChannel);
+```
+
+### WebSocket Channel
+
+```typescript
+import { createWebSocketChannel } from '@ottabase/notifications/channels';
+import { RealtimeBroadcaster } from '@ottabase/cf-realtime/server';
+
+const wsChannel = createWebSocketChannel({
+    broadcaster: new RealtimeBroadcaster(env),
+    channelPrefix: 'notification', // Default
+});
+
+manager.registerChannel(wsChannel);
+```
+
+### System Channel
+
+```typescript
+import { createSystemChannel } from '@ottabase/notifications/channels';
+
+const systemChannel = createSystemChannel({
+    adminUserIds: ['admin-1', 'admin-2'],
+    adminEmails: ['admin@example.com'],
+    enableLogging: true,
+    handler: async (notification) => {
+        // Custom system notification handler
+        console.log('System alert:', notification);
+    },
+});
+
+manager.registerChannel(systemChannel);
+
+// Send system alert
+await manager.notifySystem({
+    title: 'Database Error',
+    message: 'Connection pool exhausted',
+    eventType: 'database.error',
+    severity: 'critical',
+    metadata: { pool: 'primary', connections: 100 },
+});
+```
+
+## Async Processing with Queue
+
+```typescript
+import { Dispatcher } from '@ottabase/queue/job';
+import { createNotificationQueueHandler } from '@ottabase/notifications';
+
+// Setup queue dispatcher
+const dispatcher = new Dispatcher({
+    queue: env.NOTIFICATION_QUEUE,
+});
+
+manager.setQueue(dispatcher);
+
+// Send async notification
+await manager.notify({
+    recipient: { userId: '123', email: 'user@example.com' },
+    payload: {
+        title: 'Report Ready',
+        message: 'Your monthly report is ready to download',
+    },
+    options: {
+        async: true, // Will be queued
+        priority: 'low',
+    },
+});
+```
+
+### Queue Handler Setup
+
+```typescript
+import { createRegistry, createProcessor } from '@ottabase/queue/processor';
+import { createNotificationQueueHandler } from '@ottabase/notifications';
+
+const registry = createRegistry();
+registry.register('notifications', createNotificationQueueHandler(manager));
+
+const processor = createProcessor(registry);
+
+// In your queue consumer
+export default {
+    async queue(batch, env) {
+        await processor.process(batch);
+    },
+};
+```
+
+## User Preferences
+
+```typescript
+import { NotificationPreference } from '@ottabase/notifications/models';
+
+// Get or create preferences
+const prefs = await NotificationPreference.getOrCreate('user-123');
+
+// Update preferences
+await prefs.update({
+    enableEmail: false,
+    enableWebSocket: true,
+});
+
+// Set category preferences
+await prefs.setCategoryPreference('marketing', false);
+await prefs.setCategoryPreference('security', true);
+
+// Get enabled channels
+const channels = prefs.getEnabledChannels(); // ['websocket']
+
+// Check category
+const enabled = prefs.isCategoryEnabled('security'); // true
+```
+
+## Models
+
+### Notification Model
+
+```typescript
+import { Notification } from '@ottabase/notifications/models';
+
+// Find user's notifications
+const notifications = await Notification.find({ userId: '123' });
+
+// Get unread notifications
+const unread = await Notification.getUnread('123');
+
+// Get by category
+const security = await Notification.getByCategory('123', 'security');
+
+// Mark as read
+await notification.markAsRead();
+
+// Check status
+if (notification.isRead()) {
+    console.log('Already read');
+}
+
+if (notification.isExpired()) {
+    console.log('Notification expired');
+}
+```
+
+## Priority Levels
+
+- `low` - Non-urgent notifications (marketing, updates)
+- `normal` - Standard notifications (default)
+- `high` - Important notifications (security alerts)
+- `urgent` - Critical notifications (system failures)
+
+## Status Tracking
+
+- `pending` - Notification created, not yet sent
+- `sent` - Successfully delivered
+- `failed` - Delivery failed
+- `read` - User has read the notification
+
+## Advanced Usage
+
+### Multiple Channels
+
+```typescript
+await manager.notify({
+    recipient: {
+        userId: '123',
+        email: 'user@example.com',
+        channels: ['email', 'websocket'], // Override default
+    },
+    payload: {
+        title: 'Security Alert',
+        message: 'New login from unknown device',
+        category: 'security',
+    },
+    options: {
+        priority: 'urgent',
+    },
+});
+```
+
+### Scheduled Notifications
+
+```typescript
+await manager.notify({
+    recipient: { userId: '123', email: 'user@example.com' },
+    payload: {
+        title: 'Reminder',
+        message: 'Meeting starts in 30 minutes',
+    },
+    options: {
+        scheduledAt: new Date(Date.now() + 30 * 60 * 1000), // 30 minutes
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour
+    },
+});
+```
+
+### Custom Metadata
+
+```typescript
+await manager.notify({
+    recipient: { userId: '123', email: 'user@example.com' },
+    payload: {
+        title: 'Order Shipped',
+        message: 'Your order #12345 has been shipped',
+        metadata: {
+            orderId: '12345',
+            trackingNumber: 'ABC123',
+            carrier: 'UPS',
+        },
+    },
+});
+```
+
+## Integration with Cloudflare Workers
+
+```typescript
+import { NotificationManager } from '@ottabase/notifications';
+
+export interface Env {
+    NOTIFICATION_QUEUE: Queue;
+    RESEND_API_KEY: string;
+}
+
+export default {
+    async fetch(request: Request, env: Env) {
+        const manager = new NotificationManager({
+            defaultChannels: ['email'],
+            email: { from: 'noreply@example.com' },
+        });
+
+        // Setup channels...
+
+        await manager.notify({
+            recipient: { userId: '123', email: 'user@example.com' },
+            payload: {
+                title: 'Hello from Worker',
+                message: 'This notification was sent from a Cloudflare Worker',
+            },
+        });
+
+        return new Response('Notification sent!');
+    },
+};
+```
+
+## TypeScript Support
+
+Full TypeScript support with type definitions:
+
+```typescript
+import type {
+    Notification,
+    NotificationChannel,
+    NotificationPayload,
+    NotificationRecipient,
+    NotificationOptions,
+    SendResult,
+    SystemNotification,
+} from '@ottabase/notifications';
+```
+
+## Database Schema
+
+The package includes Drizzle schemas for SQLite:
+
+- `notifications` - Stores all notifications
+- `notification_preferences` - User notification preferences
+- `system_notifications` - System/admin alerts
+
+To use with your database, import and include in your Drizzle schema:
+
+```typescript
+import { notificationsTable, notificationPreferencesTable } from '@ottabase/notifications/models';
+```
+
+## License
+
+MIT

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,0 +1,82 @@
+{
+    "name": "@ottabase/notifications",
+    "version": "0.1.0",
+    "description": "Minimalistic notifications engine for Ottabase - multi-channel user notifications, system alerts, and real-time updates",
+    "type": "module",
+    "main": "dist/index.js",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs"
+        },
+        "./channels": {
+            "types": "./dist/channels/index.d.ts",
+            "import": "./dist/channels/index.js",
+            "require": "./dist/channels/index.cjs"
+        },
+        "./models": {
+            "types": "./dist/models/index.d.ts",
+            "import": "./dist/models/index.js",
+            "require": "./dist/models/index.cjs"
+        },
+        "./manager": {
+            "types": "./dist/manager.d.ts",
+            "import": "./dist/manager.js",
+            "require": "./dist/manager.cjs"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "scripts": {
+        "build": "tsup",
+        "dev": "tsup --watch",
+        "clean": "rimraf dist",
+        "lint": "eslint src --ext .ts",
+        "type-check": "tsc --noEmit",
+        "test": "vitest",
+        "test:coverage": "vitest --coverage"
+    },
+    "keywords": [
+        "notifications",
+        "alerts",
+        "email",
+        "websocket",
+        "realtime",
+        "pubsub",
+        "cloudflare",
+        "ottabase"
+    ],
+    "author": "",
+    "license": "MIT",
+    "dependencies": {
+        "@ottabase/cf": "workspace:*",
+        "@ottabase/email": "workspace:*",
+        "@ottabase/cf-realtime": "workspace:*",
+        "@ottabase/queue": "workspace:*",
+        "@ottabase/ottaorm": "workspace:*",
+        "drizzle-orm": "catalog:"
+    },
+    "devDependencies": {
+        "@cloudflare/workers-types": "catalog:",
+        "@types/node": "catalog:",
+        "eslint": "catalog:",
+        "rimraf": "catalog:",
+        "tsup": "catalog:",
+        "typescript": "catalog:",
+        "vitest": "catalog:"
+    },
+    "peerDependencies": {
+        "@cloudflare/workers-types": "catalog:"
+    },
+    "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+            "optional": true
+        }
+    }
+}

--- a/packages/notifications/src/__tests__/manager.test.ts
+++ b/packages/notifications/src/__tests__/manager.test.ts
@@ -230,4 +230,142 @@ describe('NotificationManager', () => {
             expect(result.error).toContain('System channel not registered');
         });
     });
+
+    describe('async queue notifications', () => {
+        it('should dispatch notification to queue when async option is enabled', async () => {
+            const dispatchedJobs: any[] = [];
+            const mockQueue = {
+                async dispatch(queueName: string, payload: any, options?: any) {
+                    dispatchedJobs.push({ queueName, payload, options });
+                },
+            };
+
+            manager.setQueue(mockQueue);
+
+            const results = await manager.notify({
+                recipient: {
+                    userId: '123',
+                    email: 'user@test.com',
+                },
+                payload: {
+                    title: 'Async Test',
+                    message: 'This should be queued',
+                },
+                options: {
+                    async: true,
+                },
+            });
+
+            expect(results).toHaveLength(1);
+            expect(results[0].success).toBe(true);
+            expect(results[0].metadata?.async).toBe(true);
+            expect(dispatchedJobs).toHaveLength(1);
+            expect(dispatchedJobs[0].queueName).toBe('notifications');
+            expect(dispatchedJobs[0].payload.notification).toBeDefined();
+            expect(dispatchedJobs[0].payload.channels).toEqual(['email']);
+        });
+
+        it('should return error when async is enabled but queue is not configured', async () => {
+            const results = await manager.notify({
+                recipient: {
+                    userId: '123',
+                    email: 'user@test.com',
+                },
+                payload: {
+                    title: 'Async Test',
+                    message: 'This should fail',
+                },
+                options: {
+                    async: true,
+                },
+            });
+
+            expect(results).toHaveLength(1);
+            expect(results[0].success).toBe(false);
+            expect(results[0].error).toContain('Queue not configured');
+        });
+    });
+
+    describe('queue handler integration', () => {
+        it('should process queued notifications via queue handler', async () => {
+            const { createNotificationQueueHandler } = await import('../queue');
+
+            const handler = createNotificationQueueHandler(manager);
+
+            const job = {
+                payload: {
+                    notification: {
+                        id: 'test-123',
+                        recipient: {
+                            userId: '123',
+                            email: 'user@test.com',
+                        },
+                        payload: {
+                            title: 'Queue Test',
+                            message: 'Processed from queue',
+                        },
+                        options: {
+                            priority: 'normal' as const,
+                        },
+                        status: 'pending' as const,
+                        createdAt: new Date(),
+                    },
+                    channels: ['email' as const, 'websocket' as const],
+                },
+            };
+
+            await handler(job);
+
+            expect(emailChannel.sentNotifications).toHaveLength(1);
+            expect(wsChannel.sentNotifications).toHaveLength(1);
+            expect(emailChannel.sentNotifications[0].payload.title).toBe('Queue Test');
+        });
+
+        it('should throw error when channel send fails to trigger retry', async () => {
+            const { createNotificationQueueHandler } = await import('../queue');
+
+            // Create a failing channel
+            const failingChannel = {
+                name: 'failing' as const,
+                async send(): Promise<SendResult> {
+                    return {
+                        success: false,
+                        error: 'Intentional failure',
+                    };
+                },
+                async isAvailable() {
+                    return true;
+                },
+            };
+
+            manager.registerChannel(failingChannel);
+
+            const handler = createNotificationQueueHandler(manager);
+
+            const job = {
+                payload: {
+                    notification: {
+                        id: 'test-456',
+                        recipient: {
+                            userId: '123',
+                            email: 'user@test.com',
+                        },
+                        payload: {
+                            title: 'Fail Test',
+                            message: 'This will fail',
+                        },
+                        options: {
+                            priority: 'normal' as const,
+                        },
+                        status: 'pending' as const,
+                        createdAt: new Date(),
+                    },
+                    channels: ['failing' as const],
+                },
+            };
+
+            // Should throw to allow queue retry
+            await expect(handler(job)).rejects.toThrow('Failed to send notification');
+        });
+    });
 });

--- a/packages/notifications/src/__tests__/manager.test.ts
+++ b/packages/notifications/src/__tests__/manager.test.ts
@@ -1,0 +1,233 @@
+// ============================================================
+// @ottabase/notifications - Manager Tests
+// ============================================================
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NotificationManager } from '../manager';
+import type { NotificationChannelHandler, Notification, SendResult } from '../types';
+
+// Mock email channel
+class MockEmailChannel implements NotificationChannelHandler {
+    name = 'email' as const;
+    sentNotifications: Notification[] = [];
+
+    async send(notification: Notification): Promise<SendResult> {
+        this.sentNotifications.push(notification);
+        return {
+            success: true,
+            messageId: notification.id,
+            metadata: { provider: 'mock-email' },
+        };
+    }
+
+    async isAvailable(): Promise<boolean> {
+        return true;
+    }
+
+    reset() {
+        this.sentNotifications = [];
+    }
+}
+
+// Mock websocket channel
+class MockWebSocketChannel implements NotificationChannelHandler {
+    name = 'websocket' as const;
+    sentNotifications: Notification[] = [];
+
+    async send(notification: Notification): Promise<SendResult> {
+        this.sentNotifications.push(notification);
+        return {
+            success: true,
+            messageId: notification.id,
+            metadata: { provider: 'mock-websocket' },
+        };
+    }
+
+    async isAvailable(): Promise<boolean> {
+        return true;
+    }
+
+    reset() {
+        this.sentNotifications = [];
+    }
+}
+
+describe('NotificationManager', () => {
+    let manager: NotificationManager;
+    let emailChannel: MockEmailChannel;
+    let wsChannel: MockWebSocketChannel;
+
+    beforeEach(() => {
+        manager = new NotificationManager({
+            defaultChannels: ['email'],
+            email: { from: 'noreply@test.com' },
+        });
+
+        emailChannel = new MockEmailChannel();
+        wsChannel = new MockWebSocketChannel();
+
+        manager.registerChannel(emailChannel);
+        manager.registerChannel(wsChannel);
+
+        emailChannel.reset();
+        wsChannel.reset();
+    });
+
+    describe('notify', () => {
+        it('should send notification via default channel', async () => {
+            const results = await manager.notify({
+                recipient: {
+                    userId: '123',
+                    email: 'user@test.com',
+                },
+                payload: {
+                    title: 'Test Notification',
+                    message: 'This is a test',
+                },
+            });
+
+            expect(results).toHaveLength(1);
+            expect(results[0].success).toBe(true);
+            expect(emailChannel.sentNotifications).toHaveLength(1);
+            expect(wsChannel.sentNotifications).toHaveLength(0);
+        });
+
+        it('should send notification via multiple channels', async () => {
+            const results = await manager.notify({
+                recipient: {
+                    userId: '123',
+                    email: 'user@test.com',
+                    channels: ['email', 'websocket'],
+                },
+                payload: {
+                    title: 'Multi-Channel Test',
+                    message: 'Sent to multiple channels',
+                },
+            });
+
+            expect(results).toHaveLength(2);
+            expect(emailChannel.sentNotifications).toHaveLength(1);
+            expect(wsChannel.sentNotifications).toHaveLength(1);
+        });
+
+        it('should set correct notification properties', async () => {
+            await manager.notify({
+                recipient: {
+                    userId: '123',
+                    email: 'user@test.com',
+                },
+                payload: {
+                    title: 'Test Title',
+                    message: 'Test Message',
+                    category: 'test',
+                    actionUrl: 'https://test.com',
+                    actionText: 'Click Here',
+                    metadata: { key: 'value' },
+                },
+                options: {
+                    priority: 'high',
+                },
+            });
+
+            const sent = emailChannel.sentNotifications[0];
+            expect(sent.payload.title).toBe('Test Title');
+            expect(sent.payload.message).toBe('Test Message');
+            expect(sent.payload.category).toBe('test');
+            expect(sent.payload.actionUrl).toBe('https://test.com');
+            expect(sent.payload.actionText).toBe('Click Here');
+            expect(sent.payload.metadata).toEqual({ key: 'value' });
+            expect(sent.options?.priority).toBe('high');
+        });
+
+        it('should generate unique notification IDs', async () => {
+            await manager.notify({
+                recipient: { userId: '1', email: 'user1@test.com' },
+                payload: { title: 'Test 1', message: 'Message 1' },
+            });
+
+            await manager.notify({
+                recipient: { userId: '2', email: 'user2@test.com' },
+                payload: { title: 'Test 2', message: 'Message 2' },
+            });
+
+            const id1 = emailChannel.sentNotifications[0].id;
+            const id2 = emailChannel.sentNotifications[1].id;
+
+            expect(id1).toBeDefined();
+            expect(id2).toBeDefined();
+            expect(id1).not.toBe(id2);
+        });
+    });
+
+    describe('channel management', () => {
+        it('should register channels', () => {
+            expect(manager.hasChannel('email')).toBe(true);
+            expect(manager.hasChannel('websocket')).toBe(true);
+        });
+
+        it('should get registered channels', () => {
+            const channels = manager.getChannels();
+            expect(channels).toContain('email');
+            expect(channels).toContain('websocket');
+        });
+
+        it('should handle missing channels gracefully', async () => {
+            const results = await manager.notify({
+                recipient: {
+                    userId: '123',
+                    email: 'user@test.com',
+                    channels: ['email', 'system'] as any,
+                },
+                payload: {
+                    title: 'Test',
+                    message: 'Test message',
+                },
+            });
+
+            expect(results).toHaveLength(2);
+            expect(results[0].success).toBe(true); // email
+            expect(results[1].success).toBe(false); // system (not registered)
+            expect(results[1].error).toContain('not registered');
+        });
+    });
+
+    describe('system notifications', () => {
+        it('should send system notifications', async () => {
+            const systemChannel = {
+                name: 'system' as const,
+                async send(notification: Notification): Promise<SendResult> {
+                    return {
+                        success: true,
+                        messageId: notification.id,
+                    };
+                },
+                async isAvailable() {
+                    return true;
+                },
+            };
+
+            manager.registerChannel(systemChannel);
+
+            const result = await manager.notifySystem({
+                title: 'System Alert',
+                message: 'Something went wrong',
+                eventType: 'system.error',
+                severity: 'critical',
+            });
+
+            expect(result.success).toBe(true);
+        });
+
+        it('should fail if system channel not registered', async () => {
+            const result = await manager.notifySystem({
+                title: 'System Alert',
+                message: 'Something went wrong',
+                eventType: 'system.error',
+                severity: 'critical',
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('System channel not registered');
+        });
+    });
+});

--- a/packages/notifications/src/__tests__/manager.test.ts
+++ b/packages/notifications/src/__tests__/manager.test.ts
@@ -2,9 +2,9 @@
 // @ottabase/notifications - Manager Tests
 // ============================================================
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationManager } from '../manager';
-import type { NotificationChannelHandler, Notification, SendResult } from '../types';
+import type { Notification, NotificationChannelHandler, SendResult } from '../types';
 
 // Mock email channel
 class MockEmailChannel implements NotificationChannelHandler {
@@ -364,8 +364,14 @@ describe('NotificationManager', () => {
                 },
             };
 
-            // Should throw to allow queue retry
-            await expect(handler(job)).rejects.toThrow('Failed to send notification');
+            // Suppress console.error for this test only (expected error)
+            const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            try {
+                // Should throw to allow queue retry
+                await expect(handler(job)).rejects.toThrow('Failed to send notification');
+            } finally {
+                spy.mockRestore();
+            }
         });
     });
 });

--- a/packages/notifications/src/channels/email.ts
+++ b/packages/notifications/src/channels/email.ts
@@ -57,25 +57,39 @@ export class EmailChannel implements NotificationChannelHandler {
             const from = this.config.from;
             const replyTo = this.config.replyTo;
 
-            // Build email content
+            // Helper to escape HTML
+            const escapeHtml = (text: string) => {
+                return text
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+            };
+
+            // Build email content with escaped values
             let html = `
-        <h2>${payload.title}</h2>
-        <p>${payload.message}</p>
+        <h2>${escapeHtml(payload.title)}</h2>
+        <p>${escapeHtml(payload.message)}</p>
       `;
 
             if (payload.actionUrl && payload.actionText) {
-                html += `
+                // Validate URL scheme
+                const url = payload.actionUrl.trim();
+                if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('/')) {
+                    html += `
           <p>
-            <a href="${payload.actionUrl}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px;">
-              ${payload.actionText}
+            <a href="${escapeHtml(url)}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px;">
+              ${escapeHtml(payload.actionText)}
             </a>
           </p>
         `;
+                }
             }
 
             // Add metadata if present
             if (payload.metadata) {
-                html += `<hr><small>Metadata: ${JSON.stringify(payload.metadata)}</small>`;
+                html += `<hr><small>Metadata: ${escapeHtml(JSON.stringify(payload.metadata))}</small>`;
             }
 
             const result = await this.config.mailer.send({

--- a/packages/notifications/src/channels/email.ts
+++ b/packages/notifications/src/channels/email.ts
@@ -1,0 +1,120 @@
+// ============================================================
+// @ottabase/notifications - Email Channel
+// ============================================================
+
+import type { Mailer } from '@ottabase/email';
+import type { Notification, NotificationChannelHandler, SendResult } from '../types';
+
+/**
+ * Email channel configuration
+ */
+export interface EmailChannelConfig {
+    /** Email mailer instance */
+    mailer: Mailer;
+    /** Default from address */
+    from: string;
+    /** Default reply-to address */
+    replyTo?: string;
+    /** Email template name (optional) */
+    template?: string;
+}
+
+/**
+ * Email notification channel handler
+ *
+ * @example
+ * ```typescript
+ * import { createResendMailer } from "@ottabase/email/providers/resend";
+ * import { EmailChannel } from "@ottabase/notifications/channels";
+ *
+ * const mailer = createResendMailer({ apiKey: "..." });
+ * const emailChannel = new EmailChannel({
+ *   mailer,
+ *   from: "noreply@example.com"
+ * });
+ *
+ * await emailChannel.send(notification);
+ * ```
+ */
+export class EmailChannel implements NotificationChannelHandler {
+    name = 'email' as const;
+    private config: EmailChannelConfig;
+
+    constructor(config: EmailChannelConfig) {
+        this.config = config;
+    }
+
+    async send(notification: Notification): Promise<SendResult> {
+        try {
+            if (!notification.recipient.email) {
+                return {
+                    success: false,
+                    error: 'No email address provided for recipient',
+                };
+            }
+
+            const { payload } = notification;
+            const from = this.config.from;
+            const replyTo = this.config.replyTo;
+
+            // Build email content
+            let html = `
+        <h2>${payload.title}</h2>
+        <p>${payload.message}</p>
+      `;
+
+            if (payload.actionUrl && payload.actionText) {
+                html += `
+          <p>
+            <a href="${payload.actionUrl}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px;">
+              ${payload.actionText}
+            </a>
+          </p>
+        `;
+            }
+
+            // Add metadata if present
+            if (payload.metadata) {
+                html += `<hr><small>Metadata: ${JSON.stringify(payload.metadata)}</small>`;
+            }
+
+            const result = await this.config.mailer.send({
+                to: notification.recipient.email,
+                from,
+                replyTo,
+                subject: payload.title,
+                html,
+                text: payload.message,
+            });
+
+            if (result.success) {
+                return {
+                    success: true,
+                    messageId: result.id,
+                    metadata: { provider: 'email' },
+                };
+            } else {
+                return {
+                    success: false,
+                    error: result.error || 'Failed to send email',
+                };
+            }
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+            };
+        }
+    }
+
+    async isAvailable(): Promise<boolean> {
+        return !!this.config.mailer;
+    }
+}
+
+/**
+ * Create an email notification channel
+ */
+export function createEmailChannel(config: EmailChannelConfig): EmailChannel {
+    return new EmailChannel(config);
+}

--- a/packages/notifications/src/channels/index.ts
+++ b/packages/notifications/src/channels/index.ts
@@ -1,0 +1,7 @@
+// ============================================================
+// @ottabase/notifications - Channels
+// ============================================================
+
+export * from './email';
+export * from './websocket';
+export * from './system';

--- a/packages/notifications/src/channels/system.ts
+++ b/packages/notifications/src/channels/system.ts
@@ -1,0 +1,151 @@
+// ============================================================
+// @ottabase/notifications - System Channel
+// ============================================================
+
+import type { Notification, NotificationChannelHandler, SendResult, SystemNotification } from '../types';
+
+/**
+ * System channel configuration
+ */
+export interface SystemChannelConfig {
+    /** Admin user IDs to notify */
+    adminUserIds: string[];
+    /** Admin emails to notify */
+    adminEmails?: string[];
+    /** Custom handler for system notifications */
+    handler?: (notification: SystemNotification) => Promise<void>;
+    /** Log system notifications */
+    enableLogging?: boolean;
+}
+
+/**
+ * System notification channel handler
+ * Used for admin/system alerts and critical notifications
+ *
+ * @example
+ * ```typescript
+ * import { SystemChannel } from "@ottabase/notifications/channels";
+ *
+ * const systemChannel = new SystemChannel({
+ *   adminUserIds: ["admin-1", "admin-2"],
+ *   adminEmails: ["admin@example.com"],
+ *   enableLogging: true
+ * });
+ *
+ * await systemChannel.sendSystemAlert({
+ *   title: "Database Error",
+ *   message: "Connection pool exhausted",
+ *   eventType: "database.error",
+ *   severity: "critical"
+ * });
+ * ```
+ */
+export class SystemChannel implements NotificationChannelHandler {
+    name = 'system' as const;
+    private config: SystemChannelConfig;
+
+    constructor(config: SystemChannelConfig) {
+        this.config = config;
+    }
+
+    async send(notification: Notification): Promise<SendResult> {
+        try {
+            const systemNotification: SystemNotification = {
+                title: notification.payload.title,
+                message: notification.payload.message,
+                eventType: notification.payload.category || 'system.notification',
+                severity: this.mapPriorityToSeverity(notification.options?.priority || 'normal'),
+                metadata: notification.payload.metadata,
+                timestamp: new Date(),
+            };
+
+            // Log if enabled
+            if (this.config.enableLogging) {
+                console.log('[SYSTEM NOTIFICATION]', {
+                    severity: systemNotification.severity,
+                    title: systemNotification.title,
+                    message: systemNotification.message,
+                    eventType: systemNotification.eventType,
+                    timestamp: systemNotification.timestamp,
+                });
+            }
+
+            // Call custom handler if provided
+            if (this.config.handler) {
+                await this.config.handler(systemNotification);
+            }
+
+            return {
+                success: true,
+                messageId: notification.id,
+                metadata: {
+                    provider: 'system',
+                    admins: this.config.adminUserIds,
+                },
+            };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+            };
+        }
+    }
+
+    /**
+     * Send a system alert to admins
+     */
+    async sendSystemAlert(alert: SystemNotification): Promise<SendResult> {
+        const notification: Notification = {
+            recipient: {
+                userId: 'system',
+                channels: ['system'],
+            },
+            payload: {
+                title: alert.title,
+                message: alert.message,
+                category: alert.eventType,
+                metadata: {
+                    severity: alert.severity,
+                    ...alert.metadata,
+                },
+            },
+            options: {
+                channels: ['system'],
+                priority: this.mapSeverityToPriority(alert.severity),
+            },
+        };
+
+        return this.send(notification);
+    }
+
+    async isAvailable(): Promise<boolean> {
+        return this.config.adminUserIds.length > 0;
+    }
+
+    private mapPriorityToSeverity(priority: string): SystemNotification['severity'] {
+        const map: Record<string, SystemNotification['severity']> = {
+            low: 'info',
+            normal: 'info',
+            high: 'warning',
+            urgent: 'critical',
+        };
+        return map[priority] || 'info';
+    }
+
+    private mapSeverityToPriority(severity: SystemNotification['severity']): 'low' | 'normal' | 'high' | 'urgent' {
+        const map: Record<SystemNotification['severity'], 'low' | 'normal' | 'high' | 'urgent'> = {
+            info: 'normal',
+            warning: 'high',
+            error: 'high',
+            critical: 'urgent',
+        };
+        return map[severity] || 'normal';
+    }
+}
+
+/**
+ * Create a system notification channel
+ */
+export function createSystemChannel(config: SystemChannelConfig): SystemChannel {
+    return new SystemChannel(config);
+}

--- a/packages/notifications/src/channels/system.ts
+++ b/packages/notifications/src/channels/system.ts
@@ -10,7 +10,11 @@ import type { Notification, NotificationChannelHandler, SendResult, SystemNotifi
 export interface SystemChannelConfig {
     /** Admin user IDs to notify */
     adminUserIds: string[];
-    /** Admin emails to notify */
+    /**
+     * Admin emails to notify
+     * Note: This is for reference only. To send emails to admins,
+     * configure an EmailChannel and use the custom handler.
+     */
     adminEmails?: string[];
     /** Custom handler for system notifications */
     handler?: (notification: SystemNotification) => Promise<void>;

--- a/packages/notifications/src/channels/websocket.ts
+++ b/packages/notifications/src/channels/websocket.ts
@@ -1,0 +1,92 @@
+// ============================================================
+// @ottabase/notifications - WebSocket/Realtime Channel
+// ============================================================
+
+import type { RealtimeBroadcaster } from '@ottabase/cf-realtime/server';
+import type { Notification, NotificationChannelHandler, SendResult } from '../types';
+
+/**
+ * WebSocket channel configuration
+ */
+export interface WebSocketChannelConfig {
+    /** Realtime broadcaster instance */
+    broadcaster: RealtimeBroadcaster;
+    /** Default channel prefix */
+    channelPrefix?: string;
+}
+
+/**
+ * WebSocket/Realtime notification channel handler
+ *
+ * @example
+ * ```typescript
+ * import { RealtimeBroadcaster } from "@ottabase/cf-realtime/server";
+ * import { WebSocketChannel } from "@ottabase/notifications/channels";
+ *
+ * const broadcaster = new RealtimeBroadcaster(env);
+ * const wsChannel = new WebSocketChannel({ broadcaster });
+ *
+ * await wsChannel.send(notification);
+ * ```
+ */
+export class WebSocketChannel implements NotificationChannelHandler {
+    name = 'websocket' as const;
+    private config: WebSocketChannelConfig;
+
+    constructor(config: WebSocketChannelConfig) {
+        this.config = config;
+    }
+
+    async send(notification: Notification): Promise<SendResult> {
+        try {
+            const { recipient, payload } = notification;
+            const prefix = this.config.channelPrefix || 'notification';
+            const channel = `${prefix}:user:${recipient.userId}`;
+
+            // Build notification message
+            const message = {
+                id: notification.id,
+                type: 'notification',
+                title: payload.title,
+                message: payload.message,
+                category: payload.category,
+                actionUrl: payload.actionUrl,
+                actionText: payload.actionText,
+                metadata: payload.metadata,
+                timestamp: new Date().toISOString(),
+            };
+
+            // Broadcast to user's channel
+            await this.config.broadcaster.broadcast({
+                channels: [channel],
+                event: 'notification',
+                data: message,
+            });
+
+            return {
+                success: true,
+                messageId: notification.id,
+                metadata: {
+                    channel,
+                    provider: 'websocket',
+                },
+            };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+            };
+        }
+    }
+
+    async isAvailable(): Promise<boolean> {
+        return !!this.config.broadcaster;
+    }
+}
+
+/**
+ * Create a websocket notification channel
+ */
+export function createWebSocketChannel(config: WebSocketChannelConfig): WebSocketChannel {
+    return new WebSocketChannel(config);
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,0 +1,51 @@
+// ============================================================
+// @ottabase/notifications
+// Minimalistic notifications engine for Ottabase
+// ============================================================
+
+/**
+ * Multi-channel notification system for Ottabase
+ *
+ * Features:
+ * - Email notifications via @ottabase/email
+ * - Real-time WebSocket notifications via @ottabase/cf-realtime
+ * - System/admin alerts
+ * - Async queue processing via @ottabase/queue
+ * - User preference management
+ * - OttaORM models for persistence
+ *
+ * @example
+ * ```typescript
+ * import { NotificationManager, createEmailChannel } from "@ottabase/notifications";
+ *
+ * const manager = new NotificationManager({
+ *   defaultChannels: ["email", "websocket"],
+ *   email: { from: "noreply@example.com" }
+ * });
+ *
+ * await manager.notify({
+ *   recipient: { userId: "123", email: "user@example.com" },
+ *   payload: {
+ *     title: "Welcome!",
+ *     message: "Thanks for signing up"
+ *   }
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Core types
+export * from './types';
+
+// Manager
+export * from './manager';
+
+// Channels
+export * from './channels';
+
+// Models
+export * from './models';
+
+// Queue integration
+export * from './queue';

--- a/packages/notifications/src/manager.ts
+++ b/packages/notifications/src/manager.ts
@@ -92,7 +92,15 @@ export class NotificationManager {
         const channels = this.determineChannels(notification);
 
         // Handle async delivery
-        if (notification.options?.async && this.queue) {
+        if (notification.options?.async) {
+            if (!this.queue) {
+                return [
+                    {
+                        success: false,
+                        error: 'Queue not configured for async notifications',
+                    },
+                ];
+            }
             return this.sendAsync(notification, channels);
         }
 

--- a/packages/notifications/src/manager.ts
+++ b/packages/notifications/src/manager.ts
@@ -186,13 +186,10 @@ export class NotificationManager {
         }
 
         try {
-            // Dispatch to queue
-            await this.queue.dispatch({
-                name: this.config.queueName!,
-                payload: {
-                    notification,
-                    channels,
-                },
+            // Dispatch to queue with correct API
+            await this.queue.dispatch(this.config.queueName!, {
+                notification,
+                channels,
             });
 
             return [
@@ -251,6 +248,13 @@ export class NotificationManager {
             critical: 'urgent',
         };
         return map[severity] || 'normal';
+    }
+
+    /**
+     * Send notification via specific channels (public method for queue handler)
+     */
+    async sendViaChannels(notification: Notification, channels: NotificationChannel[]): Promise<SendResult[]> {
+        return this.sendSync(notification, channels);
     }
 
     /**

--- a/packages/notifications/src/manager.ts
+++ b/packages/notifications/src/manager.ts
@@ -1,0 +1,276 @@
+// ============================================================
+// @ottabase/notifications - Notification Manager
+// ============================================================
+
+import type {
+    Notification,
+    NotificationChannel,
+    NotificationChannelHandler,
+    NotificationManagerConfig,
+    NotificationOptions,
+    NotificationPayload,
+    NotificationRecipient,
+    SendResult,
+    SystemNotification,
+} from './types';
+
+/**
+ * Notification Manager - Orchestrates notification delivery across multiple channels
+ *
+ * @example
+ * ```typescript
+ * import { NotificationManager } from "@ottabase/notifications/manager";
+ * import { createEmailChannel, createWebSocketChannel } from "@ottabase/notifications/channels";
+ *
+ * const manager = new NotificationManager({
+ *   defaultChannels: ["email", "websocket"],
+ *   email: { from: "noreply@example.com" }
+ * });
+ *
+ * manager.registerChannel(emailChannel);
+ * manager.registerChannel(wsChannel);
+ *
+ * await manager.notify({
+ *   recipient: { userId: "123", email: "user@example.com" },
+ *   payload: {
+ *     title: "Welcome!",
+ *     message: "Thanks for signing up"
+ *   }
+ * });
+ * ```
+ */
+export class NotificationManager {
+    private channels = new Map<NotificationChannel, NotificationChannelHandler>();
+    private config: NotificationManagerConfig;
+    private queue?: any; // Queue dispatcher
+
+    constructor(config: NotificationManagerConfig = {}) {
+        this.config = {
+            defaultChannels: config.defaultChannels || ['email'],
+            defaultPriority: config.defaultPriority || 'normal',
+            enableAsync: config.enableAsync || false,
+            queueName: config.queueName || 'notifications',
+            ...config,
+        };
+    }
+
+    /**
+     * Register a notification channel
+     */
+    registerChannel(channel: NotificationChannelHandler): void {
+        this.channels.set(channel.name, channel);
+    }
+
+    /**
+     * Set the queue dispatcher for async notifications
+     */
+    setQueue(queue: any): void {
+        this.queue = queue;
+    }
+
+    /**
+     * Send a notification to a user
+     */
+    async notify(params: {
+        recipient: NotificationRecipient;
+        payload: NotificationPayload;
+        options?: NotificationOptions;
+    }): Promise<SendResult[]> {
+        const notification: Notification = {
+            id: this.generateId(),
+            recipient: params.recipient,
+            payload: params.payload,
+            options: {
+                ...params.options,
+                priority: params.options?.priority || this.config.defaultPriority,
+            },
+            status: 'pending',
+            createdAt: new Date(),
+        };
+
+        // Determine which channels to use
+        const channels = this.determineChannels(notification);
+
+        // Handle async delivery
+        if (notification.options?.async && this.queue) {
+            return this.sendAsync(notification, channels);
+        }
+
+        // Send synchronously
+        return this.sendSync(notification, channels);
+    }
+
+    /**
+     * Send a system notification to admins
+     */
+    async notifySystem(alert: SystemNotification): Promise<SendResult> {
+        const systemChannel = this.channels.get('system');
+        if (!systemChannel) {
+            return {
+                success: false,
+                error: 'System channel not registered',
+            };
+        }
+
+        const notification: Notification = {
+            id: this.generateId(),
+            recipient: {
+                userId: 'system',
+                channels: ['system'],
+            },
+            payload: {
+                title: alert.title,
+                message: alert.message,
+                category: alert.eventType,
+                metadata: {
+                    severity: alert.severity,
+                    ...alert.metadata,
+                },
+            },
+            options: {
+                channels: ['system'],
+                priority: this.mapSeverityToPriority(alert.severity),
+            },
+            status: 'pending',
+            createdAt: new Date(),
+        };
+
+        return systemChannel.send(notification);
+    }
+
+    /**
+     * Send notification synchronously through all channels
+     */
+    private async sendSync(notification: Notification, channels: NotificationChannel[]): Promise<SendResult[]> {
+        const results: SendResult[] = [];
+
+        for (const channelName of channels) {
+            const channel = this.channels.get(channelName);
+            if (!channel) {
+                results.push({
+                    success: false,
+                    error: `Channel ${channelName} not registered`,
+                });
+                continue;
+            }
+
+            // Check if channel is available
+            const available = await channel.isAvailable();
+            if (!available) {
+                results.push({
+                    success: false,
+                    error: `Channel ${channelName} not available`,
+                });
+                continue;
+            }
+
+            // Send notification
+            const result = await channel.send(notification);
+            results.push(result);
+        }
+
+        return results;
+    }
+
+    /**
+     * Send notification asynchronously via queue
+     */
+    private async sendAsync(notification: Notification, channels: NotificationChannel[]): Promise<SendResult[]> {
+        if (!this.queue) {
+            return [
+                {
+                    success: false,
+                    error: 'Queue not configured for async notifications',
+                },
+            ];
+        }
+
+        try {
+            // Dispatch to queue
+            await this.queue.dispatch({
+                name: this.config.queueName!,
+                payload: {
+                    notification,
+                    channels,
+                },
+            });
+
+            return [
+                {
+                    success: true,
+                    messageId: notification.id,
+                    metadata: {
+                        async: true,
+                        channels,
+                    },
+                },
+            ];
+        } catch (error) {
+            return [
+                {
+                    success: false,
+                    error: error instanceof Error ? error.message : 'Unknown error',
+                },
+            ];
+        }
+    }
+
+    /**
+     * Determine which channels to use for a notification
+     */
+    private determineChannels(notification: Notification): NotificationChannel[] {
+        // Use explicit channels from options
+        if (notification.options?.channels) {
+            return notification.options.channels;
+        }
+
+        // Use recipient's preferred channels
+        if (notification.recipient.channels) {
+            return notification.recipient.channels;
+        }
+
+        // Use default channels
+        return this.config.defaultChannels || ['email'];
+    }
+
+    /**
+     * Generate a unique notification ID
+     */
+    private generateId(): string {
+        return `ntf_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    }
+
+    /**
+     * Map severity to priority
+     */
+    private mapSeverityToPriority(severity: SystemNotification['severity']): 'low' | 'normal' | 'high' | 'urgent' {
+        const map: Record<SystemNotification['severity'], 'low' | 'normal' | 'high' | 'urgent'> = {
+            info: 'normal',
+            warning: 'high',
+            error: 'high',
+            critical: 'urgent',
+        };
+        return map[severity] || 'normal';
+    }
+
+    /**
+     * Get all registered channels
+     */
+    getChannels(): NotificationChannel[] {
+        return Array.from(this.channels.keys());
+    }
+
+    /**
+     * Check if a channel is registered
+     */
+    hasChannel(channel: NotificationChannel): boolean {
+        return this.channels.has(channel);
+    }
+}
+
+/**
+ * Create a notification manager instance
+ */
+export function createNotificationManager(config?: NotificationManagerConfig): NotificationManager {
+    return new NotificationManager(config);
+}

--- a/packages/notifications/src/models/Notification.schema.ts
+++ b/packages/notifications/src/models/Notification.schema.ts
@@ -1,0 +1,114 @@
+// ============================================================
+// @ottabase/notifications - Notification table schema
+// ============================================================
+
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * Notification table schema
+ */
+export const notificationsTable = sqliteTable('notifications', {
+    id: text('id')
+        .primaryKey()
+        .$defaultFn(() => `ntf_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`),
+
+    // Recipient
+    userId: text('user_id').notNull(),
+    userEmail: text('user_email'),
+
+    // Payload
+    title: text('title').notNull(),
+    message: text('message').notNull(),
+    category: text('category'),
+    actionUrl: text('action_url'),
+    actionText: text('action_text'),
+    metadata: text('metadata'), // JSON string
+
+    // Delivery
+    channels: text('channels').notNull(), // JSON array of channel names
+    priority: text('priority').notNull().default('normal'), // low, normal, high, urgent
+    status: text('status').notNull().default('pending'), // pending, sent, failed, read
+
+    // Scheduling
+    scheduledAt: integer('scheduled_at'),
+    expiresAt: integer('expires_at'),
+
+    // Tracking
+    sentAt: integer('sent_at'),
+    readAt: integer('read_at'),
+    error: text('error'),
+
+    // Timestamps
+    createdAt: integer('created_at')
+        .$defaultFn(() => Date.now())
+        .notNull(),
+    updatedAt: integer('updated_at')
+        .$defaultFn(() => Date.now())
+        .$onUpdateFn(() => Date.now())
+        .notNull(),
+});
+
+/**
+ * Notification preference table schema
+ */
+export const notificationPreferencesTable = sqliteTable('notification_preferences', {
+    id: text('id')
+        .primaryKey()
+        .$defaultFn(() => crypto.randomUUID()),
+
+    userId: text('user_id').notNull().unique(),
+
+    // Channel preferences
+    enableEmail: integer('enable_email', { mode: 'boolean' }).notNull().default(true),
+    enableWebSocket: integer('enable_websocket', { mode: 'boolean' }).notNull().default(true),
+    enableSystem: integer('enable_system', { mode: 'boolean' }).notNull().default(false),
+
+    // Category preferences (JSON)
+    categoryPreferences: text('category_preferences'), // JSON object
+
+    // Timestamps
+    createdAt: integer('created_at')
+        .$defaultFn(() => Date.now())
+        .notNull(),
+    updatedAt: integer('updated_at')
+        .$defaultFn(() => Date.now())
+        .$onUpdateFn(() => Date.now())
+        .notNull(),
+});
+
+/**
+ * System notification table schema
+ */
+export const systemNotificationsTable = sqliteTable('system_notifications', {
+    id: text('id')
+        .primaryKey()
+        .$defaultFn(() => crypto.randomUUID()),
+
+    title: text('title').notNull(),
+    message: text('message').notNull(),
+    eventType: text('event_type').notNull(),
+    severity: text('severity').notNull().default('info'), // info, warning, error, critical
+    metadata: text('metadata'), // JSON string
+
+    // Tracking
+    acknowledged: integer('acknowledged', { mode: 'boolean' }).notNull().default(false),
+    acknowledgedBy: text('acknowledged_by'),
+    acknowledgedAt: integer('acknowledged_at'),
+
+    // Timestamps
+    createdAt: integer('created_at')
+        .$defaultFn(() => Date.now())
+        .notNull(),
+});
+
+/**
+ * Notification model types
+ */
+export type NotificationType = typeof notificationsTable.$inferSelect;
+export type NewNotificationType = typeof notificationsTable.$inferInsert;
+
+export type NotificationPreferenceType = typeof notificationPreferencesTable.$inferSelect;
+export type NewNotificationPreferenceType = typeof notificationPreferencesTable.$inferInsert;
+
+export type SystemNotificationType = typeof systemNotificationsTable.$inferSelect;
+export type NewSystemNotificationType = typeof systemNotificationsTable.$inferInsert;

--- a/packages/notifications/src/models/Notification.schema.ts
+++ b/packages/notifications/src/models/Notification.schema.ts
@@ -10,7 +10,7 @@ import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 export const notificationsTable = sqliteTable('notifications', {
     id: text('id')
         .primaryKey()
-        .$defaultFn(() => `ntf_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`),
+        .$defaultFn(() => `ntf_${crypto.randomUUID()}`),
 
     // Recipient
     userId: text('user_id').notNull(),

--- a/packages/notifications/src/models/Notification.ts
+++ b/packages/notifications/src/models/Notification.ts
@@ -82,10 +82,13 @@ export class NotificationModel extends BaseModel {
         },
         userId: {
             type: 'string',
-            editable: false,
+            editable: true,
             searchable: true,
             uiConfig: {
                 label: 'User ID',
+            },
+            formConfig: {
+                visible: false,
             },
             tableConfig: {
                 visible: true,
@@ -93,10 +96,13 @@ export class NotificationModel extends BaseModel {
         },
         userEmail: {
             type: 'string',
-            editable: false,
+            editable: true,
             searchable: true,
             uiConfig: {
                 label: 'Email',
+            },
+            formConfig: {
+                visible: false,
             },
             tableConfig: {
                 visible: true,
@@ -104,21 +110,28 @@ export class NotificationModel extends BaseModel {
         },
         title: {
             type: 'string',
-            editable: false,
+            editable: true,
             searchable: true,
             uiConfig: {
                 label: 'Title',
+            },
+            formConfig: {
+                visible: false,
             },
             tableConfig: {
                 visible: true,
             },
         },
         message: {
-            type: 'text',
-            editable: false,
+            type: 'string',
+            editable: true,
             searchable: true,
             uiConfig: {
                 label: 'Message',
+            },
+            formConfig: {
+                visible: false,
+                fieldType: 'textarea',
             },
             tableConfig: {
                 visible: true,
@@ -126,9 +139,12 @@ export class NotificationModel extends BaseModel {
         },
         category: {
             type: 'string',
-            editable: false,
+            editable: true,
             uiConfig: {
                 label: 'Category',
+            },
+            formConfig: {
+                visible: false,
             },
             tableConfig: {
                 visible: true,
@@ -146,9 +162,12 @@ export class NotificationModel extends BaseModel {
         },
         priority: {
             type: 'string',
-            editable: false,
+            editable: true,
             uiConfig: {
                 label: 'Priority',
+            },
+            formConfig: {
+                visible: false,
             },
             tableConfig: {
                 visible: true,
@@ -156,9 +175,12 @@ export class NotificationModel extends BaseModel {
         },
         channels: {
             type: 'string',
-            editable: false,
+            editable: true,
             uiConfig: {
                 label: 'Channels',
+            },
+            formConfig: {
+                visible: false,
             },
         },
         createdAt: {
@@ -197,30 +219,27 @@ export class NotificationModel extends BaseModel {
      * Mark notification as sent
      */
     async markAsSent(): Promise<void> {
-        await this.update({
-            status: 'sent',
-            sentAt: Date.now(),
-        });
+        this.set('status', 'sent');
+        this.set('sentAt', Date.now());
+        await this.save();
     }
 
     /**
      * Mark notification as read
      */
     async markAsRead(): Promise<void> {
-        await this.update({
-            status: 'read',
-            readAt: Date.now(),
-        });
+        this.set('status', 'read');
+        this.set('readAt', Date.now());
+        await this.save();
     }
 
     /**
      * Mark notification as failed
      */
     async markAsFailed(error: string): Promise<void> {
-        await this.update({
-            status: 'failed',
-            error,
-        });
+        this.set('status', 'failed');
+        this.set('error', error);
+        await this.save();
     }
 
     /**
@@ -243,17 +262,18 @@ export class NotificationModel extends BaseModel {
      * Get unread notifications for a user
      */
     static async getUnread(userId: string): Promise<NotificationModel[]> {
-        return this.find({
+        const notifications = await this.where({
             userId,
-            status: 'pending',
         });
+
+        return notifications.filter((notification) => !notification.isRead());
     }
 
     /**
      * Get notifications by category
      */
     static async getByCategory(userId: string, category: string): Promise<NotificationModel[]> {
-        return this.find({
+        return this.where({
             userId,
             category,
         });

--- a/packages/notifications/src/models/Notification.ts
+++ b/packages/notifications/src/models/Notification.ts
@@ -1,0 +1,261 @@
+// ============================================================
+// @ottabase/notifications - Notification Model
+// ============================================================
+
+import { BaseModel, type ModelFields, type PackageType } from '@ottabase/ottaorm/base';
+import { notificationsTable } from './Notification.schema';
+
+export { notificationsTable, type NewNotificationType, type NotificationType } from './Notification.schema';
+
+/**
+ * Notification model for storing user notifications
+ *
+ * @example
+ * ```typescript
+ * import { NotificationModel } from "@ottabase/notifications/models";
+ *
+ * // Find user's notifications
+ * const notifications = await NotificationModel.find({ userId: "123" });
+ *
+ * // Create notification
+ * const notification = await NotificationModel.create({
+ *   userId: "123",
+ *   userEmail: "user@example.com",
+ *   title: "Welcome",
+ *   message: "Thanks for signing up",
+ *   channels: JSON.stringify(["email", "websocket"]),
+ *   priority: "normal"
+ * });
+ *
+ * // Mark as read
+ * await notification.markAsRead();
+ * ```
+ */
+export class NotificationModel extends BaseModel {
+    static entity = 'notifications';
+    static table = notificationsTable;
+    static primaryKey = 'id';
+    static packageName = '@ottabase/notifications';
+    static packageType: PackageType = 'core';
+
+    // UI/Forms metadata
+    static displayName = 'Notification';
+    static displayNamePlural = 'Notifications';
+    static defaultSort = 'createdAt';
+    static defaultSortDirection = 'desc' as const;
+
+    static casts = {
+        createdAt: 'date' as const,
+        updatedAt: 'date' as const,
+        sentAt: 'date' as const,
+        readAt: 'date' as const,
+        scheduledAt: 'date' as const,
+        expiresAt: 'date' as const,
+    };
+
+    static writable = {
+        create: [
+            'userId',
+            'userEmail',
+            'title',
+            'message',
+            'category',
+            'actionUrl',
+            'actionText',
+            'metadata',
+            'channels',
+            'priority',
+            'scheduledAt',
+            'expiresAt',
+        ],
+        update: ['status', 'sentAt', 'readAt', 'error'],
+    };
+
+    protected static fields: ModelFields = {
+        id: {
+            type: 'id',
+            primaryKey: true,
+            editable: false,
+            uiConfig: {
+                label: 'ID',
+            },
+        },
+        userId: {
+            type: 'string',
+            editable: false,
+            searchable: true,
+            uiConfig: {
+                label: 'User ID',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        userEmail: {
+            type: 'string',
+            editable: false,
+            searchable: true,
+            uiConfig: {
+                label: 'Email',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        title: {
+            type: 'string',
+            editable: false,
+            searchable: true,
+            uiConfig: {
+                label: 'Title',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        message: {
+            type: 'text',
+            editable: false,
+            searchable: true,
+            uiConfig: {
+                label: 'Message',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        category: {
+            type: 'string',
+            editable: false,
+            uiConfig: {
+                label: 'Category',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        status: {
+            type: 'string',
+            editable: true,
+            uiConfig: {
+                label: 'Status',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        priority: {
+            type: 'string',
+            editable: false,
+            uiConfig: {
+                label: 'Priority',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        channels: {
+            type: 'string',
+            editable: false,
+            uiConfig: {
+                label: 'Channels',
+            },
+        },
+        createdAt: {
+            type: 'date',
+            editable: false,
+            uiConfig: {
+                label: 'Created',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        sentAt: {
+            type: 'date',
+            editable: false,
+            uiConfig: {
+                label: 'Sent',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        readAt: {
+            type: 'date',
+            editable: false,
+            uiConfig: {
+                label: 'Read',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+    };
+
+    /**
+     * Mark notification as sent
+     */
+    async markAsSent(): Promise<void> {
+        await this.update({
+            status: 'sent',
+            sentAt: Date.now(),
+        });
+    }
+
+    /**
+     * Mark notification as read
+     */
+    async markAsRead(): Promise<void> {
+        await this.update({
+            status: 'read',
+            readAt: Date.now(),
+        });
+    }
+
+    /**
+     * Mark notification as failed
+     */
+    async markAsFailed(error: string): Promise<void> {
+        await this.update({
+            status: 'failed',
+            error,
+        });
+    }
+
+    /**
+     * Check if notification is read
+     */
+    isRead(): boolean {
+        return this.get('status') === 'read';
+    }
+
+    /**
+     * Check if notification is expired
+     */
+    isExpired(): boolean {
+        const expiresAt = this.get('expiresAt');
+        if (!expiresAt) return false;
+        return Date.now() > expiresAt;
+    }
+
+    /**
+     * Get unread notifications for a user
+     */
+    static async getUnread(userId: string): Promise<NotificationModel[]> {
+        return this.find({
+            userId,
+            status: 'pending',
+        });
+    }
+
+    /**
+     * Get notifications by category
+     */
+    static async getByCategory(userId: string, category: string): Promise<NotificationModel[]> {
+        return this.find({
+            userId,
+            category,
+        });
+    }
+}

--- a/packages/notifications/src/models/NotificationPreference.ts
+++ b/packages/notifications/src/models/NotificationPreference.ts
@@ -1,0 +1,223 @@
+// ============================================================
+// @ottabase/notifications - Notification Preference Model
+// ============================================================
+
+import { BaseModel, type ModelFields, type PackageType } from '@ottabase/ottaorm/base';
+import { notificationPreferencesTable } from './Notification.schema';
+
+export {
+    notificationPreferencesTable,
+    type NewNotificationPreferenceType,
+    type NotificationPreferenceType,
+} from './Notification.schema';
+
+/**
+ * Notification preference model for user notification settings
+ *
+ * @example
+ * ```typescript
+ * import { NotificationPreference } from "@ottabase/notifications/models";
+ *
+ * // Get user preferences
+ * const prefs = await NotificationPreference.first({ userId: "123" });
+ *
+ * // Update preferences
+ * await prefs.update({
+ *   enableEmail: false,
+ *   enableWebSocket: true
+ * });
+ *
+ * // Get enabled channels
+ * const channels = prefs.getEnabledChannels();
+ * ```
+ */
+export class NotificationPreference extends BaseModel {
+    static entity = 'notification_preferences';
+    static table = notificationPreferencesTable;
+    static primaryKey = 'id';
+    static packageName = '@ottabase/notifications';
+    static packageType: PackageType = 'core';
+
+    // UI/Forms metadata
+    static displayName = 'Notification Preference';
+    static displayNamePlural = 'Notification Preferences';
+    static defaultSort = 'createdAt';
+    static defaultSortDirection = 'desc' as const;
+
+    static casts = {
+        createdAt: 'date' as const,
+        updatedAt: 'date' as const,
+        enableEmail: 'boolean' as const,
+        enableWebSocket: 'boolean' as const,
+        enableSystem: 'boolean' as const,
+    };
+
+    static writable = {
+        create: ['userId', 'enableEmail', 'enableWebSocket', 'enableSystem', 'categoryPreferences'],
+        update: ['enableEmail', 'enableWebSocket', 'enableSystem', 'categoryPreferences'],
+    };
+
+    protected static fields: ModelFields = {
+        id: {
+            type: 'id',
+            primaryKey: true,
+            editable: false,
+            uiConfig: {
+                label: 'ID',
+            },
+        },
+        userId: {
+            type: 'string',
+            editable: false,
+            searchable: true,
+            unique: true,
+            uiConfig: {
+                label: 'User ID',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        enableEmail: {
+            type: 'boolean',
+            editable: true,
+            uiConfig: {
+                label: 'Enable Email',
+                description: 'Receive email notifications',
+            },
+            formConfig: {
+                visible: true,
+                fieldType: 'checkbox',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        enableWebSocket: {
+            type: 'boolean',
+            editable: true,
+            uiConfig: {
+                label: 'Enable WebSocket',
+                description: 'Receive real-time notifications',
+            },
+            formConfig: {
+                visible: true,
+                fieldType: 'checkbox',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        enableSystem: {
+            type: 'boolean',
+            editable: true,
+            uiConfig: {
+                label: 'Enable System',
+                description: 'Receive system notifications',
+            },
+            formConfig: {
+                visible: true,
+                fieldType: 'checkbox',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        categoryPreferences: {
+            type: 'string',
+            editable: true,
+            uiConfig: {
+                label: 'Category Preferences',
+                description: 'JSON object of category-specific preferences',
+            },
+        },
+        createdAt: {
+            type: 'date',
+            editable: false,
+            uiConfig: {
+                label: 'Created',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+        updatedAt: {
+            type: 'date',
+            editable: false,
+            uiConfig: {
+                label: 'Updated',
+            },
+            tableConfig: {
+                visible: true,
+            },
+        },
+    };
+
+    /**
+     * Get enabled notification channels
+     */
+    getEnabledChannels(): string[] {
+        const channels: string[] = [];
+
+        if (this.get('enableEmail')) channels.push('email');
+        if (this.get('enableWebSocket')) channels.push('websocket');
+        if (this.get('enableSystem')) channels.push('system');
+
+        return channels;
+    }
+
+    /**
+     * Check if a specific category is enabled
+     */
+    isCategoryEnabled(category: string): boolean {
+        const prefs = this.get('categoryPreferences');
+        if (!prefs) return true; // Default to enabled
+
+        try {
+            const parsed = JSON.parse(prefs);
+            return parsed[category] !== false;
+        } catch {
+            return true;
+        }
+    }
+
+    /**
+     * Set category preference
+     */
+    async setCategoryPreference(category: string, enabled: boolean): Promise<void> {
+        const prefs = this.get('categoryPreferences');
+        let parsed: Record<string, boolean> = {};
+
+        if (prefs) {
+            try {
+                parsed = JSON.parse(prefs);
+            } catch {
+                parsed = {};
+            }
+        }
+
+        parsed[category] = enabled;
+
+        await this.update({
+            categoryPreferences: JSON.stringify(parsed),
+        });
+    }
+
+    /**
+     * Get or create preferences for a user
+     */
+    static async getOrCreate(userId: string): Promise<NotificationPreference> {
+        let prefs = await this.first({ userId });
+
+        if (!prefs) {
+            prefs = await this.create({
+                userId,
+                enableEmail: true,
+                enableWebSocket: true,
+                enableSystem: false,
+            });
+        }
+
+        return prefs;
+    }
+}

--- a/packages/notifications/src/models/NotificationPreference.ts
+++ b/packages/notifications/src/models/NotificationPreference.ts
@@ -68,11 +68,14 @@ export class NotificationPreference extends BaseModel {
         },
         userId: {
             type: 'string',
-            editable: false,
+            editable: true,
             searchable: true,
             unique: true,
             uiConfig: {
                 label: 'User ID',
+            },
+            formConfig: {
+                visible: false,
             },
             tableConfig: {
                 visible: true,
@@ -87,7 +90,7 @@ export class NotificationPreference extends BaseModel {
             },
             formConfig: {
                 visible: true,
-                fieldType: 'checkbox',
+                fieldType: 'boolean',
             },
             tableConfig: {
                 visible: true,
@@ -102,7 +105,7 @@ export class NotificationPreference extends BaseModel {
             },
             formConfig: {
                 visible: true,
-                fieldType: 'checkbox',
+                fieldType: 'boolean',
             },
             tableConfig: {
                 visible: true,
@@ -117,7 +120,7 @@ export class NotificationPreference extends BaseModel {
             },
             formConfig: {
                 visible: true,
-                fieldType: 'checkbox',
+                fieldType: 'boolean',
             },
             tableConfig: {
                 visible: true,
@@ -198,9 +201,8 @@ export class NotificationPreference extends BaseModel {
 
         parsed[category] = enabled;
 
-        await this.update({
-            categoryPreferences: JSON.stringify(parsed),
-        });
+        this.set('categoryPreferences', JSON.stringify(parsed));
+        await this.save();
     }
 
     /**

--- a/packages/notifications/src/models/index.ts
+++ b/packages/notifications/src/models/index.ts
@@ -4,3 +4,7 @@
 
 // Export schemas for database setup
 export * from './Notification.schema';
+
+// Export model classes for application use
+export { NotificationModel } from './Notification';
+export { NotificationPreference } from './NotificationPreference';

--- a/packages/notifications/src/models/index.ts
+++ b/packages/notifications/src/models/index.ts
@@ -1,0 +1,6 @@
+// ============================================================
+// @ottabase/notifications - Models & Schemas
+// ============================================================
+
+// Export schemas for database setup
+export * from './Notification.schema';

--- a/packages/notifications/src/queue.ts
+++ b/packages/notifications/src/queue.ts
@@ -28,33 +28,21 @@ export interface NotificationJob {
  * ```
  */
 export function createNotificationQueueHandler(manager: NotificationManager) {
-    return async (message: { body: NotificationJob }) => {
-        const { notification, channels } = message.body;
+    return async (job: { payload: NotificationJob }) => {
+        const { notification, channels } = job.payload;
 
-        // Send notification through each channel
-        for (const channelName of channels) {
-            const channel = (manager as any).channels.get(channelName);
-            if (!channel) {
-                console.warn(`Channel ${channelName} not registered`);
-                continue;
+        // Use public method to send via channels
+        try {
+            const results = await (manager as any).sendViaChannels(notification, channels);
+            // Check if any sends failed
+            const hasFailures = results.some((r: any) => !r.success);
+            if (hasFailures) {
+                // Throw to trigger queue retry
+                throw new Error('Failed to send notification via one or more channels');
             }
-
-            // Check if channel is available
-            const available = await channel.isAvailable();
-            if (!available) {
-                console.warn(`Channel ${channelName} not available`);
-                continue;
-            }
-
-            // Send notification
-            try {
-                const result = await channel.send(notification);
-                if (!result.success) {
-                    console.error(`Failed to send notification via ${channelName}:`, result.error);
-                }
-            } catch (error) {
-                console.error(`Error sending notification via ${channelName}:`, error);
-            }
+        } catch (error) {
+            console.error('Error in notification queue handler:', error);
+            throw error; // Propagate to allow queue retry
         }
     };
 }

--- a/packages/notifications/src/queue.ts
+++ b/packages/notifications/src/queue.ts
@@ -1,0 +1,90 @@
+// ============================================================
+// @ottabase/notifications - Queue Integration
+// ============================================================
+
+import type { NotificationManager } from './manager';
+import type { Notification, NotificationChannel } from './types';
+
+/**
+ * Notification job payload
+ */
+export interface NotificationJob {
+    notification: Notification;
+    channels: NotificationChannel[];
+}
+
+/**
+ * Create a notification queue handler
+ *
+ * @example
+ * ```typescript
+ * import { createNotificationQueueHandler } from "@ottabase/notifications";
+ * import { createRegistry } from "@ottabase/queue/processor";
+ *
+ * const registry = createRegistry();
+ * const handler = createNotificationQueueHandler(notificationManager);
+ *
+ * registry.register("notifications", handler);
+ * ```
+ */
+export function createNotificationQueueHandler(manager: NotificationManager) {
+    return async (message: { body: NotificationJob }) => {
+        const { notification, channels } = message.body;
+
+        // Send notification through each channel
+        for (const channelName of channels) {
+            const channel = (manager as any).channels.get(channelName);
+            if (!channel) {
+                console.warn(`Channel ${channelName} not registered`);
+                continue;
+            }
+
+            // Check if channel is available
+            const available = await channel.isAvailable();
+            if (!available) {
+                console.warn(`Channel ${channelName} not available`);
+                continue;
+            }
+
+            // Send notification
+            try {
+                const result = await channel.send(notification);
+                if (!result.success) {
+                    console.error(`Failed to send notification via ${channelName}:`, result.error);
+                }
+            } catch (error) {
+                console.error(`Error sending notification via ${channelName}:`, error);
+            }
+        }
+    };
+}
+
+/**
+ * Dispatch a notification to the queue
+ *
+ * @example
+ * ```typescript
+ * import { dispatchNotification } from "@ottabase/notifications";
+ * import { Dispatcher } from "@ottabase/queue/job";
+ *
+ * const dispatcher = new Dispatcher({ queue: env.QUEUE });
+ *
+ * await dispatchNotification(dispatcher, {
+ *   notification: {
+ *     recipient: { userId: "123", email: "user@example.com" },
+ *     payload: { title: "Hello", message: "World" }
+ *   },
+ *   channels: ["email", "websocket"]
+ * });
+ * ```
+ */
+export async function dispatchNotification(
+    dispatcher: any,
+    job: NotificationJob,
+    options?: {
+        priority?: 'low' | 'normal' | 'high' | 'urgent';
+        delay?: number;
+    },
+): Promise<void> {
+    await dispatcher.dispatch('notifications', job, options);
+}

--- a/packages/notifications/src/queue.ts
+++ b/packages/notifications/src/queue.ts
@@ -33,9 +33,9 @@ export function createNotificationQueueHandler(manager: NotificationManager) {
 
         // Use public method to send via channels
         try {
-            const results = await (manager as any).sendViaChannels(notification, channels);
+            const results = await manager.sendViaChannels(notification, channels);
             // Check if any sends failed
-            const hasFailures = results.some((r: any) => !r.success);
+            const hasFailures = results.some((r) => !r.success);
             if (hasFailures) {
                 // Throw to trigger queue retry
                 throw new Error('Failed to send notification via one or more channels');

--- a/packages/notifications/src/types/index.ts
+++ b/packages/notifications/src/types/index.ts
@@ -1,0 +1,160 @@
+// ============================================================
+// @ottabase/notifications - Core Types
+// ============================================================
+
+/**
+ * Notification channels supported by the system
+ */
+export type NotificationChannel = 'email' | 'websocket' | 'system';
+
+/**
+ * Notification priority levels
+ */
+export type NotificationPriority = 'low' | 'normal' | 'high' | 'urgent';
+
+/**
+ * Notification status
+ */
+export type NotificationStatus = 'pending' | 'sent' | 'failed' | 'read';
+
+/**
+ * Base notification payload
+ */
+export interface NotificationPayload {
+    /** Notification title */
+    title: string;
+    /** Notification message body */
+    message: string;
+    /** Additional metadata */
+    metadata?: Record<string, any>;
+    /** Link/action URL */
+    actionUrl?: string;
+    /** Action button text */
+    actionText?: string;
+    /** Notification category/type */
+    category?: string;
+}
+
+/**
+ * Notification recipient configuration
+ */
+export interface NotificationRecipient {
+    /** User ID */
+    userId: string;
+    /** User email (for email channel) */
+    email?: string;
+    /** User preferred channels */
+    channels?: NotificationChannel[];
+    /** User preferences/settings */
+    preferences?: Record<string, any>;
+}
+
+/**
+ * Notification options
+ */
+export interface NotificationOptions {
+    /** Channel(s) to send notification through */
+    channels?: NotificationChannel[];
+    /** Notification priority */
+    priority?: NotificationPriority;
+    /** Schedule notification for later */
+    scheduledAt?: Date;
+    /** Expire notification after date */
+    expiresAt?: Date;
+    /** Send asynchronously via queue */
+    async?: boolean;
+    /** Retry configuration */
+    retry?: {
+        attempts?: number;
+        delay?: number;
+    };
+}
+
+/**
+ * Complete notification object
+ */
+export interface Notification {
+    /** Notification ID */
+    id?: string;
+    /** Recipient information */
+    recipient: NotificationRecipient;
+    /** Notification payload */
+    payload: NotificationPayload;
+    /** Notification options */
+    options?: NotificationOptions;
+    /** Notification status */
+    status?: NotificationStatus;
+    /** Created timestamp */
+    createdAt?: Date;
+    /** Sent timestamp */
+    sentAt?: Date;
+    /** Read timestamp */
+    readAt?: Date;
+    /** Error information if failed */
+    error?: string;
+}
+
+/**
+ * Channel handler interface - all channels must implement this
+ */
+export interface NotificationChannelHandler {
+    /** Channel name */
+    name: NotificationChannel;
+    /** Send notification through this channel */
+    send(notification: Notification): Promise<SendResult>;
+    /** Check if channel is available */
+    isAvailable(): Promise<boolean>;
+}
+
+/**
+ * Result of sending a notification
+ */
+export interface SendResult {
+    success: boolean;
+    messageId?: string;
+    error?: string;
+    metadata?: Record<string, any>;
+}
+
+/**
+ * System notification (for admins)
+ */
+export interface SystemNotification {
+    /** Notification title */
+    title: string;
+    /** Notification message */
+    message: string;
+    /** System event type */
+    eventType: string;
+    /** Severity level */
+    severity: 'info' | 'warning' | 'error' | 'critical';
+    /** Event metadata */
+    metadata?: Record<string, any>;
+    /** Timestamp */
+    timestamp?: Date;
+}
+
+/**
+ * Notification manager configuration
+ */
+export interface NotificationManagerConfig {
+    /** Default channels to use */
+    defaultChannels?: NotificationChannel[];
+    /** Default priority */
+    defaultPriority?: NotificationPriority;
+    /** Enable async processing */
+    enableAsync?: boolean;
+    /** Queue name for async processing */
+    queueName?: string;
+    /** Email configuration */
+    email?: {
+        from: string;
+        replyTo?: string;
+    };
+    /** Websocket configuration */
+    websocket?: {
+        endpoint?: string;
+    };
+    /** System notification recipients */
+    systemAdmins?: string[];
+}

--- a/packages/notifications/tsconfig.json
+++ b/packages/notifications/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/notifications/tsup.config.ts
+++ b/packages/notifications/tsup.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
         '@ottabase/cf',
         '@ottabase/email',
         '@ottabase/cf-realtime',
+        '@ottabase/cf-realtime/server',
         '@ottabase/queue',
         '@ottabase/ottaorm',
+        '@ottabase/ottaorm/base',
     ],
 });

--- a/packages/notifications/tsup.config.ts
+++ b/packages/notifications/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts', 'src/channels/index.ts', 'src/models/index.ts', 'src/manager.ts'],
+    format: ['cjs', 'esm'],
+    dts: {
+        compilerOptions: {
+            skipLibCheck: true,
+        },
+    },
+    clean: true,
+    external: [
+        'drizzle-orm',
+        '@ottabase/cf',
+        '@ottabase/email',
+        '@ottabase/cf-realtime',
+        '@ottabase/queue',
+        '@ottabase/ottaorm',
+    ],
+});

--- a/packages/notifications/vitest.config.ts
+++ b/packages/notifications/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+    plugins: [react()],
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        // Use the repo-root setup file
+        setupFiles: ['../../vitest.setup.ts'],
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'json', 'html', 'lcov', 'text-summary'],
+            exclude: ['node_modules/', 'dist/', '**/*.config.ts', '**/*.d.ts'],
+            all: true,
+            lines: 70,
+            functions: 70,
+            branches: 65,
+            statements: 70,
+        },
+        include: ['src/**/*.{test,spec}.{ts,tsx}', '__tests__/**/*.{test,spec}.{ts,tsx}'],
+    },
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './src'),
+        },
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         version: 7.28.5(@babel/core@7.28.6)
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
+        version: 10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
       '@storybook/addon-links':
         specifier: 'catalog:'
         version: 10.2.3(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -274,13 +274,13 @@ importers:
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@typescript-eslint/eslint-plugin':
         specifier: 'catalog:'
-        version: 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 'catalog:'
-        version: 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/ui':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18)
@@ -295,7 +295,7 @@ importers:
         version: 7.1.3(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
       eslint-plugin-storybook:
         specifier: 'catalog:'
-        version: 10.2.3(eslint@9.39.2(jiti@1.21.7))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 10.2.3(eslint@9.39.2(jiti@2.6.1))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       happy-dom:
         specifier: ^20.4.0
         version: 20.4.0
@@ -334,13 +334,13 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(@swc/core@1.13.5)(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.13.5)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       turbo:
         specifier: ^2.8.0
         version: 2.8.0
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@1.21.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack:
         specifier: ^5.104.1
         version: 5.104.1(@swc/core@1.13.5)(esbuild@0.27.2)
@@ -455,7 +455,7 @@ importers:
         version: link:../../packages/ui-tailwind
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
+        version: 10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
       '@storybook/addon-links':
         specifier: 'catalog:'
         version: 10.2.3(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -488,13 +488,13 @@ importers:
         version: 0.31.8
       eslint:
         specifier: 'catalog:'
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@1.21.7)
       eslint-config-next:
         specifier: ^16.1.1
-        version: 16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       localflare:
         specifier: 'catalog:'
-        version: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
@@ -1135,6 +1135,49 @@ importers:
         specifier: '*'
         version: 10.38.0
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.28
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.2(jiti@2.6.1)
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.2
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(@swc/core@1.13.5)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.28)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/notifications:
+    dependencies:
+      '@ottabase/cf':
+        specifier: workspace:*
+        version: link:../cf
+      '@ottabase/cf-realtime':
+        specifier: workspace:*
+        version: link:../cf-realtime
+      '@ottabase/email':
+        specifier: workspace:*
+        version: link:../email
+      '@ottabase/ottaorm':
+        specifier: workspace:*
+        version: link:../ottaorm
+      '@ottabase/queue':
+        specifier: workspace:*
+        version: link:../queue
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.38.4(@cloudflare/workers-types@4.20251225.0)(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.15.6)(@types/react@19.2.7)(prisma@5.22.0)(react@19.2.4)
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20251225.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.28
@@ -8531,6 +8574,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
@@ -8544,7 +8588,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -16901,10 +16945,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
+  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
+      '@storybook/csf-plugin': 10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -16918,10 +16962,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
+  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
+      '@storybook/csf-plugin': 10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -17006,24 +17050,24 @@ snapshots:
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
+  '@storybook/csf-plugin@10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
     dependencies:
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.25.4
       rollup: 4.57.1
-      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(@swc/core@1.13.5)(esbuild@0.25.4)
 
-  '@storybook/csf-plugin@10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
+  '@storybook/csf-plugin@10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
     dependencies:
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.57.1
-      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(@swc/core@1.13.5)(esbuild@0.27.2)
 
   '@storybook/global@5.0.0': {}
@@ -17306,12 +17350,12 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 5.4.21(@types/node@20.19.28)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/history@1.145.7': {}
 
@@ -17580,30 +17624,14 @@ snapshots:
     dependencies:
       '@types/node': 25.1.0
 
-  '@typescript-eslint/eslint-plugin@8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.52.0
-      '@typescript-eslint/type-utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.52.0
-      eslint: 9.39.2(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.54.0
       eslint: 9.39.2(jiti@1.21.7)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -17612,26 +17640,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.54.0
+      eslint: 9.39.2(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.52.0
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.52.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -17672,25 +17716,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -17730,24 +17774,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
       '@typescript-eslint/scope-manager': 8.52.0
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -17845,7 +17889,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -17853,7 +17897,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -17874,13 +17918,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -17916,7 +17960,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@1.21.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -19202,18 +19246,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.1
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@1.21.7))
       globals: 16.4.0
-      typescript-eslint: 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19230,33 +19274,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19265,9 +19309,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19279,13 +19323,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -19295,7 +19339,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -19304,18 +19348,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/parser': 7.28.6
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       hermes-parser: 0.25.1
       zod: 3.25.76
       zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -19323,7 +19367,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -19337,10 +19381,10 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@10.2.3(eslint@9.39.2(jiti@1.21.7))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+  eslint-plugin-storybook@10.2.3(eslint@9.39.2(jiti@2.6.1))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
@@ -20552,7 +20596,7 @@ snapshots:
       - '@types/react-dom'
       - vite
 
-  localflare-dashboard@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  localflare-dashboard@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.0.0(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@fontsource-variable/figtree': 5.2.10
@@ -20563,7 +20607,7 @@ snapshots:
       '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tailwindcss/vite': 4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tailwindcss/vite': 4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/react-query': 5.90.12(react@19.2.4)
       '@tanstack/react-table': 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
@@ -20603,11 +20647,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  localflare@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  localflare@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       cac: 6.7.14
       localflare-core: 0.1.2
-      localflare-dashboard: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      localflare-dashboard: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       localflare-server: 0.1.2
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -22714,35 +22758,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.13.5)(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.2)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3
-      esbuild: 0.27.2
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
-      resolve-from: 5.0.0
-      rollup: 4.57.1
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@swc/core': 1.13.5
-      postcss: 8.5.6
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsup@8.5.1(@swc/core@1.13.5)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
@@ -22854,13 +22869,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -23075,6 +23090,24 @@ snapshots:
       sugarss: 5.0.1(postcss@8.5.6)
       terser: 5.46.0
 
+  vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.28
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      lightningcss: 1.30.2
+      sugarss: 5.0.1(postcss@8.5.6)
+      terser: 5.46.0
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
@@ -23093,7 +23126,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -23104,7 +23137,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.1.0
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.6.1
       lightningcss: 1.30.2
       sugarss: 5.0.1(postcss@8.5.6)
       terser: 5.46.0
@@ -23114,7 +23147,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.28)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -23152,10 +23185,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@1.21.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -23172,7 +23205,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -43,7 +43,7 @@ global.ResizeObserver = class ResizeObserver {
 
 // Suppress console errors in tests (optional - remove if you want to see them)
 const originalError = console.error;
-beforeAll(() => {
+beforeAll(async () => {
     console.error = (...args: any[]) => {
         if (
             typeof args[0] === 'string' &&
@@ -54,6 +54,16 @@ beforeAll(() => {
         }
         originalError.call(console, ...args);
     };
+
+    // Mock AuditLog.create to avoid DB driver calls during unit tests
+    try {
+        const AuditLogModule = await import('./packages/ottaorm/src/models/AuditLog');
+        if (AuditLogModule?.AuditLog && typeof AuditLogModule.AuditLog.create === 'function') {
+            vi.spyOn(AuditLogModule.AuditLog, 'create').mockResolvedValue({} as any);
+        }
+    } catch (e) {
+        // ignore if module not present in this environment
+    }
 });
 
 afterAll(() => {


### PR DESCRIPTION
Create a minimalistic notifications engine for the Ottabase monorepo with support for:

- Multi-channel delivery (email, websocket, system)
- Email notifications via @ottabase/email integration
- Real-time websocket notifications via @ottabase/cf-realtime
- System/admin alerts for critical events
- Async queue processing via @ottabase/queue
- User notification preferences
- Database schemas for persistence (Drizzle ORM)
- Priority levels (low, normal, high, urgent)
- Status tracking (pending, sent, failed, read)
- Comprehensive TypeScript support
- Tree-shakeable exports
- Full documentation and examples

The package follows the established monorepo patterns and integrates seamlessly with existing Ottabase infrastructure.

https://claude.ai/code/session_01FB6uEjz755NoHSCynPr4vq