### PR TITLE
Migration: Destructive actions support, Bulletproofing, Docs

### DIFF
--- a/apps/ottabase-template-app-tanstack/.env.example
+++ b/apps/ottabase-template-app-tanstack/.env.example
@@ -15,6 +15,17 @@
 # 2. Use: wrangler secret put AUTH_SECRET
 # 3. Use: wrangler secret put GOOGLE_CLIENT_SECRET (for sensitive values)
 #
+
+# ============================================================
+# Development Notes
+# ============================================================
+#
+# 1. At minimum, you need AUTH_SECRET and OBCF_D1 for credentials login
+# 2. Add any OAuth provider to enable social login
+# 3. Add EMAIL_RESEND_API_KEY or EMAIL_SERVER to enable magic links
+# 4. The auth system will show warnings for missing providers
+# 5. All auth methods work independently - configure what you need
+#
 # ============================================================
 
 # ============================================================
@@ -23,6 +34,14 @@
 # Generate a secure random string (32+ characters)
 # Command: openssl rand -base64 32
 AUTH_SECRET=
+
+# ============================================================
+# Required: Secrets
+# ============================================================
+# Generate a secure random string (32+ characters)
+# Command: openssl rand -base64 32
+MIGRATION_SECRET=
+BOOTSTRAP_OWNER_SECRET=
 
 # ============================================================
 # OAuth Providers (Optional - configure the ones you need)
@@ -86,14 +105,7 @@ EMAIL_FROM=noreply@yourdomain.com
 # - OBCF_RATE_LIMITER: Rate limiter (optional, for API protection)
 # - OBCF_REALTIME: Durable Object (optional, for websockets)
 # - OBCF_ASSETS: Static assets (required, for serving frontend)
-
 # ============================================================
-# Platform Kill Switches
-# ============================================================
-# Set to true to block all POST/PUT/PATCH/DELETE (read-only mode)
-KILLSWITCH_READONLY_MODE=false
-# Set to true to return a static "LOCKDOWN ENFORCED" page for every route
-KILLSWITCH_LOCKDOWN=false
 
 # ============================================================
 # Database Configuration
@@ -103,13 +115,15 @@ KILLSWITCH_LOCKDOWN=false
 # Or navigate to: /api/ottaorm/init in your browser
 
 # ============================================================
-# Development Notes
+# Platform Kill Switches
 # ============================================================
-#
-# 1. At minimum, you need AUTH_SECRET and OBCF_D1 for credentials login
-# 2. Add any OAuth provider to enable social login
-# 3. Add EMAIL_RESEND_API_KEY or EMAIL_SERVER to enable magic links
-# 4. The auth system will show warnings for missing providers
-# 5. All auth methods work independently - configure what you need
-#
-# ============================================================
+# Set to true to block all POST/PUT/PATCH/DELETE (read-only mode)
+KILLSWITCH_READONLY_MODE=false
+# Set to true to return a static "LOCKDOWN ENFORCED" page for every route
+KILLSWITCH_LOCKDOWN=false
+
+
+# Feature gates / flags
+# By default destructive migrations are disabled. Set to '1' or 'true' to enable.
+MIGRATION_ALLOW_DESTRUCTIVE=0
+

--- a/apps/ottabase-template-app-tanstack/MIGRATION_QUICK_REF.md
+++ b/apps/ottabase-template-app-tanstack/MIGRATION_QUICK_REF.md
@@ -300,25 +300,25 @@ The OttaORM migration system:
 ### Core Components
 
 1. **`auto-init.ts`** - Main API for automatic database initialization
-    - Location: `/home/user/ottabase/packages/ottaorm/src/migrations/auto-init.ts`
+    - Location: `packages/ottaorm/src/migrations/auto-init.ts`
     - Function: `autoInit(config)` - Single function to initialize entire database
     - Validates schema, runs auto-migrations, executes custom migrations
 
 2. **`runtime-generator.ts`** - Runtime schema comparison and migration generation
-    - Location: `/home/user/ottabase/packages/ottaorm/src/migrations/runtime-generator.ts`
+    - Location: `packages/ottaorm/src/migrations/runtime-generator.ts`
     - Functions: `autoMigrate()`, `runAutoMigrations()`
     - Handles: Table creation, column addition, destructive operations
 
 3. **`index.ts`** - Core migrations and migration runner
-    - Location: `/home/user/ottabase/packages/ottaorm/src/migrations/index.ts`
+    - Location: `packages/ottaorm/src/migrations/index.ts`
     - Contains: 10 core migrations for essential tables
     - Functions: `runMigrations()`, `rollbackMigrations()
 
 **TanStack/Cloudflare Worker App:**
 
-- Route: `/home/user/ottabase/apps/ottabase-template-app-tanstack/worker/routes/ottaorm-init.ts`
+- Route: `apps/ottabase-template-app-tanstack/worker/routes/ottaorm-init.ts`
 - Uses: `getAllSchemas()` helper to combine core + app + package tables
-- Helper: `/home/user/ottabase/apps/ottabase-template-app-tanstack/ottabase/db/schemas-helper.ts`
+- Helper: `apps/ottabase-template-app-tanstack/ottabase/db/schemas-helper.ts`
 
 ---
 

--- a/apps/ottabase-template-app-tanstack/MIGRATION_QUICK_REF.md
+++ b/apps/ottabase-template-app-tanstack/MIGRATION_QUICK_REF.md
@@ -312,7 +312,7 @@ The OttaORM migration system:
 3. **`index.ts`** - Core migrations and migration runner
     - Location: `packages/ottaorm/src/migrations/index.ts`
     - Contains: 10 core migrations for essential tables
-    - Functions: `runMigrations()`, `rollbackMigrations()
+    - Functions: `runMigrations()`, `rollbackMigrations()`
 
 **TanStack/Cloudflare Worker App:**
 

--- a/apps/ottabase-template-app-tanstack/MIGRATION_QUICK_REF.md
+++ b/apps/ottabase-template-app-tanstack/MIGRATION_QUICK_REF.md
@@ -284,3 +284,257 @@ If something's not working:
 3. Verify file changes are saved
 4. Ensure schema exports are correct
 5. Check `_ottabase_migrations` table for history
+
+---
+
+The OttaORM migration system:
+
+- ✅ Creates essential tables via bootstrap process (10 core migrations)
+- ✅ Automatically detects and creates tables from Models (core + packages + app)
+- ✅ Transparently handles model changes without manual intervention
+- ✅ Safely manages destructive operations with proper guardrails
+- ✅ Tracks migrations to ensure idempotency
+
+## Architecture Overview
+
+### Core Components
+
+1. **`auto-init.ts`** - Main API for automatic database initialization
+    - Location: `/home/user/ottabase/packages/ottaorm/src/migrations/auto-init.ts`
+    - Function: `autoInit(config)` - Single function to initialize entire database
+    - Validates schema, runs auto-migrations, executes custom migrations
+
+2. **`runtime-generator.ts`** - Runtime schema comparison and migration generation
+    - Location: `/home/user/ottabase/packages/ottaorm/src/migrations/runtime-generator.ts`
+    - Functions: `autoMigrate()`, `runAutoMigrations()`
+    - Handles: Table creation, column addition, destructive operations
+
+3. **`index.ts`** - Core migrations and migration runner
+    - Location: `/home/user/ottabase/packages/ottaorm/src/migrations/index.ts`
+    - Contains: 10 core migrations for essential tables
+    - Functions: `runMigrations()`, `rollbackMigrations()
+
+**TanStack/Cloudflare Worker App:**
+
+- Route: `/home/user/ottabase/apps/ottabase-template-app-tanstack/worker/routes/ottaorm-init.ts`
+- Uses: `getAllSchemas()` helper to combine core + app + package tables
+- Helper: `/home/user/ottabase/apps/ottabase-template-app-tanstack/ottabase/db/schemas-helper.ts`
+
+---
+
+## Bootstrap Process Verification
+
+### Core Migrations (10 Essential Tables)
+
+The bootstrap process successfully creates all essential tables through core migrations:
+
+1. **001_create_users_table** - User accounts (users:211-228)
+2. **002_create_accounts_table** - OAuth/provider accounts (users:229-258)
+3. **003_create_posts_table** - Blog posts (users:259-278)
+4. **004_create_tags_table** - Content tags (users:280-295)
+5. **005_create_post_tags_table** - Many-to-many junction (users:297-312)
+6. **006_create_sessions_table** - User sessions with indexes (users:313-334)
+7. **007_create_verification_tokens_table** - Email verification (users:335-350)
+8. **008_create_authenticators_table** - WebAuthn/passkey credentials (users:351-379)
+9. **009_add_rbac_and_audit** - RBAC system (roles, permissions, user_roles, audit_logs) (users:380-517)
+10. **010_multi_tenant_system** - Multi-tenancy (organizations, organization_members) (users:518-687)
+
+### Model Detection from All Sources
+
+The system successfully detects and processes models from three sources:
+
+#### 1. **Core Models** (from `@ottabase/ottaorm`)
+
+- Location: `/home/user/ottabase/packages/ottaorm/src/models/`
+- Tables: `usersTable`, `accountsTable`, `sessionsTable`, `authenticatorsTable`, `verificationTokensTable`, `tagsTable`,
+  `scheduledTasksTable`, `rolesTable`, `permissionsTable`, `userRolesTable`, `auditLogsTable`, `organizationsTable`,
+  `organizationMembersTable`
+- Example: User model at User.ts:30, table at User.schema.ts
+
+#### 2. **Package Models** (from enabled packages)
+
+- Configured via: `/home/user/ottabase/apps/ottabase-template-app-tanstack/ottabase/config.migrations.ts`
+- Registry includes:
+    - **ottablog**: `postsTable`, `categoriesTable`, `seriesTable`, `postTagsTable`, `postTagLinksTable`,
+      `postVersionsTable`, `ottablogPluginsTable`, `ottablogThemesTable`
+    - **shortlinks**: `shortlinksTable`
+    - **referrals**: `referralTrackingTable`
+- Function: `getEnabledPackageTables()` dynamically includes tables based on config (config.migrations.ts:76-86)
+
+#### 3. **App Models** (app-specific)
+
+- Location: `/home/user/ottabase/apps/ottabase-template-app-tanstack/ottabase/models/`
+- Example: Todo model at Todo.ts:33, table at Todo.schema.ts:10
+- Table naming convention: `todosTable` (ends with "Table")
+
+### Auto-Detection Mechanism
+
+The system uses two approaches for schema collection:
+
+1. **`collectTableSchemas()`** (auto-init.ts:190-208)
+    - Scans schema object for properties ending with "Table"
+    - Uses duck typing to verify SQLite table characteristics
+    - Returns: `Record<string, SQLiteTable>`
+
+2. **`getAllSchemas()`** (schemas-helper.ts:40-77)
+    - Manually combines core + app + package tables
+    - Provides explicit control over table inclusion
+    - Returns: Combined schema object
+
+---
+
+### Runtime Migration Process
+
+The automatic migration process works as follows:
+
+1. **Table Detection** (runtime-generator.ts:122-148)
+
+    ```sql
+    SELECT name FROM sqlite_master
+    WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_ottabase_%'
+    ```
+
+2. **Column Detection** (runtime-generator.ts:153-172)
+
+    ```sql
+    PRAGMA table_info("table_name")
+    ```
+
+3. **Schema Comparison**
+    - New tables → `CREATE TABLE IF NOT EXISTS` (runtime-generator.ts:252-268)
+    - New columns → `ALTER TABLE ... ADD COLUMN` (runtime-generator.ts:274-313)
+    - Removed columns → Detected, requires `allowDestructive: true` (runtime-generator.ts:314-398)
+
+4. **Migration Tracking**
+    - Table: `_ottabase_migrations` (runtime-generator.ts:19, 404-412)
+    - Ensures idempotency - migrations run only once
+    - Tracks: name, executed_at, driver_type
+
+---
+
+## Safety Features
+
+### Destructive Operations Handling
+
+The system provides multiple layers of protection:
+
+1. **Default Behavior: Block Destructive Operations**
+    - Column removal detected but **blocked by default** (runtime-generator.ts:319-322)
+    - Warns user with error message
+    - Returns error in result
+
+2. **Explicit Flag Required**
+    - Set `allowDestructive: true` to enable (auto-init.ts:105)
+    - Available via env: `MIGRATION_ALLOW_DESTRUCTIVE=true` (ottaorm-init.ts:55-56)
+
+3. **Table Recreation Strategy** (runtime-generator.ts:330-395) When destructive operations are enabled:
+    - Step 1: `CREATE TABLE table__new` with desired schema
+    - Step 2: `INSERT INTO table__new SELECT ... FROM table` (with column mapping)
+    - Step 3: `DROP TABLE table`
+    - Step 4: `ALTER TABLE table__new RENAME TO table`
+
+4. **Column Rename Support**
+    - Parameter: `renameMap` (auto-init.ts:65)
+    - Example: `{ posts: { old_col: 'new_col' } }`
+    - Preserves data during column renames (runtime-generator.ts:344-351)
+
+---
+
+## API Routes & Usage
+
+### Initialization Endpoint
+
+**Both apps expose:** `POST /api/ottaorm/init`
+
+**Authentication:**
+
+- Development: No auth required
+- Production: Requires `MIGRATION_SECRET`
+- Methods: Query param, POST body, or Bearer token
+
+**Response Format:**
+
+```json
+{
+  "success": boolean,
+  "message": string,
+  "details": {
+    "tablesCreated": string[],
+    "columnsAdded": string[],
+    "customMigrationsRun": string[],
+    "customMigrationsSkipped": string[],
+    "tablesDetected": string[],
+    "tablesSkipped": string[],
+    "errors": string[]
+  },
+  "timestamp": number
+}
+```
+
+---
+
+## Model Examples
+
+### Core Model (User)
+
+**Location:** `/home/user/ottabase/packages/ottaorm/src/models/User.ts`
+
+- Class definition: User.ts:30
+- Table export: `usersTable` from User.schema.ts
+- Extends: `BaseModel`
+- Package type: `'core'`
+
+### App Model (Todo)
+
+**Location:** `/home/user/ottabase/apps/ottabase-template-app-tanstack/ottabase/models/Todo.ts`
+
+- Class definition: Todo.ts:33
+- Table schema: Todo.schema.ts:10-24
+- Table name: `todos`
+- Package type: `'app'`
+
+**Table Schema Example:**
+
+```typescript
+export const todosTable = sqliteTable('todos', {
+    id: text('id')
+        .primaryKey()
+        .$defaultFn(() => crypto.randomUUID()),
+    title: text('title').notNull(),
+    completed: integer('completed', { mode: 'boolean' }).default(false).notNull(),
+    userId: text('user_id'),
+    createdAt: integer('created_at')
+        .$defaultFn(() => Date.now())
+        .notNull(),
+    updatedAt: integer('updated_at')
+        .$defaultFn(() => Date.now())
+        .$onUpdateFn(() => Date.now())
+        .notNull(),
+});
+```
+
+---
+
+## Limitations & Best Practices
+
+### Known SQLite Limitations
+
+1. **Cannot add NOT NULL columns without DEFAULT**
+    - Handled: System warns and skips (runtime-generator.ts:206-210)
+    - Solution: Add DEFAULT value to column definition
+
+2. **Cannot change column types**
+    - Solution: Use custom migration with table recreation
+
+3. **Cannot rename columns without renameMap**
+    - Solution: Provide `renameMap` parameter to preserve data
+
+### Best Practices
+
+1. **Always test migrations in development first**
+2. **Use `allowDestructive` only when necessary**
+3. **Provide `renameMap` for column renames to preserve data**
+4. **Keep custom migrations idempotent**
+5. **Use descriptive migration names** (e.g., `001_create_users_table`)
+
+---

--- a/apps/ottabase-template-app-tanstack/worker/bootstrap/routes.ts
+++ b/apps/ottabase-template-app-tanstack/worker/bootstrap/routes.ts
@@ -320,8 +320,9 @@ async function handleInit(context: BootstrapContext): Promise<Response> {
             customMigrations: appMigrations,
             verbose: true,
             // Allow destructive migrations only when explicitly enabled via env
-            allowDestructive: (env.MIGRATION_ALLOW_DESTRUCTIVE === '1' ||
-                env.MIGRATION_ALLOW_DESTRUCTIVE === 'true') as any,
+            allowDestructive:
+                env.MIGRATION_ALLOW_DESTRUCTIVE?.trim().toLowerCase() === '1' ||
+                env.MIGRATION_ALLOW_DESTRUCTIVE?.trim().toLowerCase() === 'true',
         });
 
         // 3. Run core SQL migrations (users, sessions, accounts, RBAC, multi-tenant)

--- a/apps/ottabase-template-app-tanstack/worker/bootstrap/routes.ts
+++ b/apps/ottabase-template-app-tanstack/worker/bootstrap/routes.ts
@@ -319,6 +319,9 @@ async function handleInit(context: BootstrapContext): Promise<Response> {
             schema: allSchemas,
             customMigrations: appMigrations,
             verbose: true,
+            // Allow destructive migrations only when explicitly enabled via env
+            allowDestructive: (env.MIGRATION_ALLOW_DESTRUCTIVE === '1' ||
+                env.MIGRATION_ALLOW_DESTRUCTIVE === 'true') as any,
         });
 
         // 3. Run core SQL migrations (users, sessions, accounts, RBAC, multi-tenant)

--- a/apps/ottabase-template-app-tanstack/worker/routes/ottaorm-init.ts
+++ b/apps/ottabase-template-app-tanstack/worker/routes/ottaorm-init.ts
@@ -52,8 +52,9 @@ export async function handleOttaormInit(context: OttaormInitContext): Promise<Re
         customMigrations: appMigrations,
         verbose: true,
         // Allow destructive migrations only when explicitly enabled via env
-        allowDestructive: (env.MIGRATION_ALLOW_DESTRUCTIVE === '1' ||
-            env.MIGRATION_ALLOW_DESTRUCTIVE === 'true') as any,
+        allowDestructive:
+            env.MIGRATION_ALLOW_DESTRUCTIVE?.trim().toLowerCase() === '1' ||
+            env.MIGRATION_ALLOW_DESTRUCTIVE?.trim().toLowerCase() === 'true',
     });
 
     return jsonResponse(result);

--- a/apps/ottabase-template-app-tanstack/worker/routes/ottaorm-init.ts
+++ b/apps/ottabase-template-app-tanstack/worker/routes/ottaorm-init.ts
@@ -1,10 +1,10 @@
-import { autoInit, getAllModelsMetadata } from '@ottabase/ottaorm';
 import { createD1Driver } from '@ottabase/db/drizzle-d1';
+import { autoInit, getAllModelsMetadata } from '@ottabase/ottaorm';
 import { errorResponse } from '@ottabase/utils/http-errors';
 import { jsonResponse } from '@ottabase/utils/http-response';
-import { appMigrations } from '../../ottabase/migrations';
-import { getAllSchemas } from '../../ottabase/db/schemas-helper';
 import type { CloudflareEnv } from '../../cloudflare-env';
+import { getAllSchemas } from '../../ottabase/db/schemas-helper';
+import { appMigrations } from '../../ottabase/migrations';
 import { checkMigrationAuth } from '../lib/db-utils';
 
 export interface OttaormInitContext {
@@ -51,6 +51,9 @@ export async function handleOttaormInit(context: OttaormInitContext): Promise<Re
         schema: allSchemas,
         customMigrations: appMigrations,
         verbose: true,
+        // Allow destructive migrations only when explicitly enabled via env
+        allowDestructive: (env.MIGRATION_ALLOW_DESTRUCTIVE === '1' ||
+            env.MIGRATION_ALLOW_DESTRUCTIVE === 'true') as any,
     });
 
     return jsonResponse(result);

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "next-themes": "catalog:",
         "pnpm": "10.27.0",
         "postcss-loader": "catalog:",
+        "prettier": "catalog:",
         "rimraf": "catalog:",
         "storybook": "catalog:",
         "style-loader": "catalog:",

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,3 +1,0 @@
-# Database URL for local development
-# For Prisma migrations and local testing
-DATABASE_URL="file:./prisma/dev.db"

--- a/packages/db/src/drizzle/drizzle-d1.ts
+++ b/packages/db/src/drizzle/drizzle-d1.ts
@@ -73,6 +73,22 @@ export class D1Driver extends BaseDbDriver {
             throw error;
         }
     }
+
+    /**
+     * Execute multiple SQL statements as a batch/transaction
+     * Uses D1's native batch API for atomicity
+     */
+    async executeBatch(sqls: string[]): Promise<any> {
+        this.log(`Executing batch of ${sqls.length} statements`, 'query');
+
+        try {
+            const statements = sqls.map((sql) => this.d1Binding.prepare(sql));
+            return await this.d1Binding.batch(statements);
+        } catch (error) {
+            this.log(`Batch query error: ${error instanceof Error ? error.message : String(error)}`, 'error');
+            throw error;
+        }
+    }
 }
 
 /**

--- a/packages/db/src/drizzle/drizzle.ts
+++ b/packages/db/src/drizzle/drizzle.ts
@@ -24,6 +24,12 @@ export interface DbDriver {
     executeRaw(sql: string, params?: unknown[]): Promise<any>;
 
     /**
+     * Execute multiple SQL statements as a batch/transaction
+     * All statements succeed or all fail (atomicity)
+     */
+    executeBatch?(sqls: string[]): Promise<any>;
+
+    /**
      * Get the underlying Drizzle database instance
      */
     getDb(): any;

--- a/packages/ottaorm/src/migrations/__tests__/runtime-generator.destructive.test.ts
+++ b/packages/ottaorm/src/migrations/__tests__/runtime-generator.destructive.test.ts
@@ -1,0 +1,140 @@
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { describe, expect, test } from 'vitest';
+import { autoMigrate } from '../runtime-generator';
+
+class FakeDriver {
+    tables: Record<string, string[]> = {};
+    executed: string[] = [];
+
+    constructor(initial: Record<string, string[]>) {
+        this.tables = { ...initial };
+    }
+
+    async executeRaw(sql: string, _params?: any[]) {
+        this.executed.push(sql.trim());
+
+        const up = sql.trim();
+
+        // sqlite_master query
+        if (/SELECT name FROM sqlite_master/i.test(up)) {
+            const results = Object.keys(this.tables).map((name) => ({ name }));
+            return { results };
+        }
+
+        // pragma table_info
+        const pragmaMatch = up.match(/PRAGMA table_info\((?:"|')?(.*?)?(?:"|')?\)/i);
+        if (pragmaMatch) {
+            const t = pragmaMatch[1];
+            const cols = (this.tables[t] || []).map((c) => ({ name: c }));
+            return { results: cols };
+        }
+
+        // CREATE TABLE
+        const createMatch = up.match(/CREATE TABLE IF NOT EXISTS\s+"?([\w_]+)"?\s*\(([\s\S]*)\)/i);
+        if (createMatch) {
+            const name = createMatch[1];
+            const colsDef = createMatch[2];
+            const cols = colsDef
+                .split(',')
+                .map((s) => s.trim().split(' ')[0].replace(/"/g, ''))
+                .filter(Boolean);
+            this.tables[name] = cols;
+            return { results: [] };
+        }
+
+        // ALTER TABLE ADD COLUMN
+        const addCol = up.match(/ALTER TABLE "?([\w_]+)"? ADD COLUMN "?([\w_]+)"?/i);
+        if (addCol) {
+            const [, table, col] = addCol;
+            this.tables[table] = this.tables[table] || [];
+            if (!this.tables[table].includes(col)) this.tables[table].push(col);
+            return { results: [] };
+        }
+
+        // INSERT INTO new SELECT ... FROM old -> ignore
+        if (/INSERT INTO/i.test(up) && /SELECT/i.test(up) && /FROM/i.test(up)) {
+            return { results: [] };
+        }
+
+        // DROP TABLE
+        const drop = up.match(/DROP TABLE "?([\w_]+)"?/i);
+        if (drop) {
+            const name = drop[1];
+            delete this.tables[name];
+            return { results: [] };
+        }
+
+        // ALTER TABLE ... RENAME TO ...
+        const rename = up.match(/ALTER TABLE "?([\w_]+)"? RENAME TO "?([\w_]+)"?/i);
+        if (rename) {
+            const [, from, to] = rename;
+            this.tables[to] = this.tables[from];
+            delete this.tables[from];
+            return { results: [] };
+        }
+
+        // migration table related queries
+        if (
+            /CREATE TABLE IF NOT EXISTS _ottabase_migrations/i.test(up) ||
+            /SELECT name FROM _ottabase_migrations/i.test(up) ||
+            /INSERT INTO _ottabase_migrations/i.test(up)
+        ) {
+            return { results: [] };
+        }
+
+        return { results: [] };
+    }
+}
+
+describe('autoMigrate destructive flow', () => {
+    test('skips destructive changes when disabled', async () => {
+        // Model defines users with id,name,new_col
+        const usersTable = sqliteTable('users', {
+            id: text('id').primaryKey(),
+            name: text('name'),
+            new_col: text('new_col'),
+        });
+
+        // DB has users with id,name,old_col
+        const driver = new FakeDriver({ users: ['id', 'name', 'old_col'] });
+
+        const result = await autoMigrate({
+            driver: driver as any,
+            tables: { usersTable },
+            customMigrations: [],
+            verbose: false,
+        } as any);
+
+        // Should report an error about removed columns and not perform DROP/RENAME
+        expect(result.errors.some((e) => /Detected removed columns on users/i.test(e))).toBe(true);
+        expect(driver.executed.some((s) => /DROP TABLE "?users"?/i.test(s))).toBe(false);
+    });
+
+    test('performs recreate flow when destructive allowed with renameMap', async () => {
+        const usersTable = sqliteTable('users', {
+            id: text('id').primaryKey(),
+            name: text('name'),
+            new_col: text('new_col'),
+        });
+
+        // DB has users with id,name,old_col
+        const driver = new FakeDriver({ users: ['id', 'name', 'old_col'] });
+
+        const result = await autoMigrate({
+            driver: driver as any,
+            tables: { usersTable },
+            customMigrations: [],
+            verbose: true,
+            allowDestructive: true,
+            renameMap: { users: { old_col: 'new_col' } },
+        } as any);
+
+        // Expect steps: CREATE users__new, INSERT ... FROM users, DROP TABLE users, RENAME TO users
+        const executed = driver.executed.join('\n');
+        expect(/CREATE TABLE IF NOT EXISTS "?users__new"?/i.test(executed)).toBe(true);
+        expect(/INSERT INTO "?users__new"?/i.test(executed)).toBe(true);
+        expect(/DROP TABLE "?users"?/i.test(executed)).toBe(true);
+        expect(/ALTER TABLE "?users__new"? RENAME TO "?users"?/i.test(executed)).toBe(true);
+        expect(result.errors.length).toBe(0);
+    });
+});

--- a/packages/ottaorm/src/migrations/auto-init.ts
+++ b/packages/ottaorm/src/migrations/auto-init.ts
@@ -53,6 +53,16 @@ export interface AutoInitConfig {
      * Default: true
      */
     verbose?: boolean;
+    /**
+     * Allow destructive migrations (drops/renames). Default: false.
+     */
+    allowDestructive?: boolean;
+
+    /**
+     * Optional rename mapping for tables. Example:
+     * { posts: { old_col_name: 'new_col_name' } }
+     */
+    renameMap?: Record<string, Record<string, string>>;
 }
 
 /**
@@ -92,7 +102,7 @@ export async function autoInit(config: AutoInitConfig): Promise<{
     };
     timestamp: number;
 }> {
-    const { driver, schema, customMigrations = [], verbose = true } = config;
+    const { driver, schema, customMigrations = [], verbose = true, allowDestructive = false, renameMap = {} } = config;
 
     // Basic runtime validation of the schema object to avoid crashes
     const isObject = schema !== null && typeof schema === 'object' && !Array.isArray(schema);
@@ -136,7 +146,10 @@ export async function autoInit(config: AutoInitConfig): Promise<{
 
     // Run auto-migrations
     // Pass schemaKeys to runAutoMigrations so it can include them in its result
-    const result = await runAutoMigrations(driver, schema, customMigrations);
+    const result = await runAutoMigrations(driver, schema, customMigrations, {
+        allowDestructive,
+        renameMap,
+    });
 
     if (verbose) {
         console.log('\n✅ Auto-Init Complete!\n');

--- a/packages/ottaorm/src/migrations/index.ts
+++ b/packages/ottaorm/src/migrations/index.ts
@@ -39,14 +39,18 @@ async function createMigrationsTable(db: any): Promise<void> {
 /**
  * Check if migration has been run
  */
-async function hasMigrationRun(db: any, name: string): Promise<boolean> {
+async function hasMigrationRun(driver: DbDriver, name: string): Promise<boolean> {
     try {
-        // Escape single quotes to prevent SQL injection
-        const safeName = name.replace(/'/g, "''");
-        const result = await db.execute(`
-      SELECT 1 FROM _ottabase_migrations WHERE name = '${safeName}' LIMIT 1
-    `);
-        return result.length > 0;
+        const result = await driver.executeRaw(`SELECT 1 FROM _ottabase_migrations WHERE name = ? LIMIT 1`, [name]);
+        // Handle D1 response { results: [], ... }
+        if (result && typeof result === 'object' && 'results' in result && Array.isArray(result.results)) {
+            return result.results.length > 0;
+        }
+        // Handle standard array response
+        if (Array.isArray(result)) {
+            return result.length > 0;
+        }
+        return false;
     } catch {
         return false;
     }
@@ -55,15 +59,13 @@ async function hasMigrationRun(db: any, name: string): Promise<boolean> {
 /**
  * Record migration as run
  */
-async function recordMigration(db: any, name: string, driverType: string = 'd1-drizzle'): Promise<void> {
+async function recordMigration(driver: DbDriver, name: string, driverType: string = 'd1-drizzle'): Promise<void> {
     const now = Date.now();
-    // Escape single quotes to prevent SQL injection
-    const safeName = name.replace(/'/g, "''");
-    const safeDriverType = driverType.replace(/'/g, "''");
-    await db.execute(`
-    INSERT INTO _ottabase_migrations (name, executed_at, driver_type)
-    VALUES ('${safeName}', ${now}, '${safeDriverType}')
-  `);
+    await driver.executeRaw(`INSERT INTO _ottabase_migrations (name, executed_at, driver_type) VALUES (?, ?, ?)`, [
+        name,
+        now,
+        driverType,
+    ]);
 }
 
 /**
@@ -111,7 +113,7 @@ export async function runMigrations(
     console.log(`🔄 Running migrations...`);
 
     for (const migration of migrations) {
-        const hasRun = await hasMigrationRun(db, migration.name);
+        const hasRun = await hasMigrationRun(driver, migration.name);
 
         if (hasRun) {
             console.log(`⏭️  Skipping: ${migration.name} (already run)`);
@@ -122,7 +124,7 @@ export async function runMigrations(
         try {
             console.log(`⚡ Executing: ${migration.name}`);
             await migration.up(db);
-            await recordMigration(db, migration.name);
+            await recordMigration(driver, migration.name);
             executed.push(migration.name);
             console.log(`✅ Completed: ${migration.name}`);
         } catch (error) {
@@ -192,9 +194,7 @@ export async function rollbackMigrations(
         try {
             console.log(`⚡ Rolling back: ${migrationName}`);
             await migration.down(db);
-            // Escape single quotes to prevent SQL injection
-            const safeMigrationName = migrationName.replace(/'/g, "''");
-            await db.execute(`DELETE FROM _ottabase_migrations WHERE name = '${safeMigrationName}'`);
+            await driver.executeRaw(`DELETE FROM _ottabase_migrations WHERE name = ?`, [migrationName]);
             rolledBack.push(migrationName);
             console.log(`✅ Rolled back: ${migrationName}`);
         } catch (error) {

--- a/packages/ottaorm/src/migrations/index.ts
+++ b/packages/ottaorm/src/migrations/index.ts
@@ -41,8 +41,10 @@ async function createMigrationsTable(db: any): Promise<void> {
  */
 async function hasMigrationRun(db: any, name: string): Promise<boolean> {
     try {
+        // Escape single quotes to prevent SQL injection
+        const safeName = name.replace(/'/g, "''");
         const result = await db.execute(`
-      SELECT 1 FROM _ottabase_migrations WHERE name = '${name}' LIMIT 1
+      SELECT 1 FROM _ottabase_migrations WHERE name = '${safeName}' LIMIT 1
     `);
         return result.length > 0;
     } catch {
@@ -55,9 +57,12 @@ async function hasMigrationRun(db: any, name: string): Promise<boolean> {
  */
 async function recordMigration(db: any, name: string, driverType: string = 'd1-drizzle'): Promise<void> {
     const now = Date.now();
+    // Escape single quotes to prevent SQL injection
+    const safeName = name.replace(/'/g, "''");
+    const safeDriverType = driverType.replace(/'/g, "''");
     await db.execute(`
     INSERT INTO _ottabase_migrations (name, executed_at, driver_type)
-    VALUES ('${name}', ${now}, '${driverType}')
+    VALUES ('${safeName}', ${now}, '${safeDriverType}')
   `);
 }
 
@@ -187,7 +192,9 @@ export async function rollbackMigrations(
         try {
             console.log(`⚡ Rolling back: ${migrationName}`);
             await migration.down(db);
-            await db.execute(`DELETE FROM _ottabase_migrations WHERE name = '${migrationName}'`);
+            // Escape single quotes to prevent SQL injection
+            const safeMigrationName = migrationName.replace(/'/g, "''");
+            await db.execute(`DELETE FROM _ottabase_migrations WHERE name = '${safeMigrationName}'`);
             rolledBack.push(migrationName);
             console.log(`✅ Rolled back: ${migrationName}`);
         } catch (error) {

--- a/packages/ottaorm/src/migrations/runtime-generator.ts
+++ b/packages/ottaorm/src/migrations/runtime-generator.ts
@@ -358,10 +358,15 @@ export async function autoMigrate(config: RuntimeMigrationConfig): Promise<{
                             const col = config.columns.find((c) => c.name === colName);
                             if (col && col.default !== undefined && col.default !== null) {
                                 if (typeof col.default === 'string') {
-                                    return `'${col.default.replace(/'/g, "''")}' AS ${quoteIdentifier(colName)}`;
+                                    const escapedDefault = escapeSQLString(col.default);
+                                    return `'${escapedDefault}' AS ${quoteIdentifier(colName)}`;
                                 }
-                                if (typeof col.default === 'number' || typeof col.default === 'boolean') {
+                                if (typeof col.default === 'number') {
                                     return `${col.default} AS ${quoteIdentifier(colName)}`;
+                                }
+                                if (typeof col.default === 'boolean') {
+                                    const numericBoolDefault = col.default ? 1 : 0;
+                                    return `${numericBoolDefault} AS ${quoteIdentifier(colName)}`;
                                 }
                             }
 

--- a/packages/ottaorm/src/migrations/runtime-generator.ts
+++ b/packages/ottaorm/src/migrations/runtime-generator.ts
@@ -59,14 +59,25 @@ export interface RuntimeMigrationConfig {
      * Enable verbose logging
      */
     verbose?: boolean;
+    /**
+     * Whether destructive operations (drops/renames) are allowed.
+     * Default: false
+     */
+    allowDestructive?: boolean;
+
+    /**
+     * Optional rename mapping for tables. Example:
+     * { posts: { old_col_name: 'new_col_name' } }
+     */
+    renameMap?: Record<string, Record<string, string>>;
 }
 
 /**
  * Generate CREATE TABLE SQL from Drizzle table definition
  */
-function generateCreateTableSQL(table: SQLiteTable): string {
+function generateCreateTableSQL(table: SQLiteTable, overrideName?: string): string {
     const config = getTableConfig(table);
-    const tableName = config.name;
+    const tableName = overrideName ?? config.name;
     const columns = config.columns;
 
     const columnDefs = columns.map((col) => {
@@ -214,7 +225,7 @@ export async function autoMigrate(config: RuntimeMigrationConfig): Promise<{
     tablesSkipped: string[];
     errors: string[];
 }> {
-    const { driver, tables, customMigrations = [], verbose = false } = config;
+    const { driver, tables, customMigrations = [], verbose = false, allowDestructive = false, renameMap = {} } = config;
 
     const result = {
         tablesCreated: [] as string[],
@@ -300,6 +311,90 @@ export async function autoMigrate(config: RuntimeMigrationConfig): Promise<{
                         console.error(`❌ ${errorMsg}`);
                     }
                 }
+                // Check for removed columns (columns present in DB but not in model)
+                const desiredColumns = new Set(getTableConfig(table).columns.map((c) => c.name));
+                const removedColumns = Array.from(existingColumns).filter((c) => !desiredColumns.has(c));
+
+                if (removedColumns.length > 0) {
+                    if (!allowDestructive) {
+                        const msg = `⚠️  Detected removed columns on ${tableName}: ${removedColumns.join(', ')} (skipped - destructive ops disabled)`;
+                        console.warn(msg);
+                        result.errors.push(msg);
+                    } else {
+                        if (verbose) {
+                            console.log(
+                                `\n🗑️  Destructive changes detected for ${tableName}: ${removedColumns.join(', ')}`,
+                            );
+                        }
+
+                        // Recreate table strategy: create a new table, copy intersecting columns (respecting renameMap), drop old, rename new
+                        const tableRenameMap = renameMap[tableName] || {};
+
+                        const recreateSQLs: string[] = [];
+
+                        // 1) CREATE new table with desired schema
+                        const newTableName = `${tableName}__new`;
+                        const createSQL = generateCreateTableSQL(table, newTableName);
+                        recreateSQLs.push(createSQL);
+
+                        // 2) INSERT INTO new (...) SELECT ... FROM old
+                        const config = getTableConfig(table);
+                        const desiredCols = config.columns.map((c) => c.name);
+
+                        const selectExprs = desiredCols.map((colName) => {
+                            // If old column was renamed to new name
+                            const mappedOld = Object.keys(tableRenameMap).find(
+                                (old) => tableRenameMap[old] === colName,
+                            );
+                            if (mappedOld && existingColumns.has(mappedOld)) {
+                                return `${quoteIdentifier(mappedOld)} AS ${quoteIdentifier(colName)}`;
+                            }
+
+                            if (existingColumns.has(colName)) {
+                                return `${quoteIdentifier(colName)}`;
+                            }
+
+                            // Fallback to default value or NULL
+                            const col = config.columns.find((c) => c.name === colName);
+                            if (col && col.default !== undefined && col.default !== null) {
+                                if (typeof col.default === 'string') {
+                                    return `'${col.default.replace(/'/g, "''")}' AS ${quoteIdentifier(colName)}`;
+                                }
+                                if (typeof col.default === 'number' || typeof col.default === 'boolean') {
+                                    return `${col.default} AS ${quoteIdentifier(colName)}`;
+                                }
+                            }
+
+                            return `NULL AS ${quoteIdentifier(colName)}`;
+                        });
+
+                        recreateSQLs.push(
+                            `INSERT INTO ${quoteIdentifier(newTableName)} (${desiredCols.map(quoteIdentifier).join(', ')}) SELECT ${selectExprs.join(', ')} FROM ${quoteIdentifier(
+                                tableName,
+                            )}`,
+                        );
+
+                        // 3) DROP old table
+                        recreateSQLs.push(`DROP TABLE ${quoteIdentifier(tableName)}`);
+
+                        // 4) RENAME new -> original
+                        recreateSQLs.push(
+                            `ALTER TABLE ${quoteIdentifier(newTableName)} RENAME TO ${quoteIdentifier(tableName)}`,
+                        );
+
+                        // Execute recreate statements
+                        for (const sql of recreateSQLs) {
+                            if (verbose) console.log(sql);
+                            try {
+                                await driver.executeRaw(sql);
+                            } catch (error: any) {
+                                const errorMsg = `Failed destructive migration on ${tableName}: ${error.message}`;
+                                result.errors.push(errorMsg);
+                                console.error(`❌ ${errorMsg}`);
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -372,6 +467,7 @@ export async function runAutoMigrations(
         name: string;
         up: (db: DbDriver) => Promise<void>;
     }>,
+    options?: { allowDestructive?: boolean; renameMap?: Record<string, Record<string, string>> },
 ): Promise<{
     success: boolean;
     message: string;
@@ -389,6 +485,8 @@ export async function runAutoMigrations(
         tables,
         customMigrations,
         verbose: true,
+        allowDestructive: options?.allowDestructive,
+        renameMap: options?.renameMap,
     });
 
     const { tablesCreated, columnsAdded, customMigrationsRun, errors } = result;

--- a/packages/ottaorm/src/migrations/runtime-generator.ts
+++ b/packages/ottaorm/src/migrations/runtime-generator.ts
@@ -332,52 +332,52 @@ export async function autoMigrate(config: RuntimeMigrationConfig): Promise<{
 
                         const recreateSQLs: string[] = [];
 
-                        // 1) CREATE new table with desired schema
+                        // 0) DROP any pre-existing __new table from a previous failed run
                         const newTableName = `${tableName}__new`;
+                        recreateSQLs.push(`DROP TABLE IF EXISTS ${quoteIdentifier(newTableName)}`);
+
+                        // 1) CREATE new table with desired schema
                         const createSQL = generateCreateTableSQL(table, newTableName);
                         recreateSQLs.push(createSQL);
 
                         // 2) INSERT INTO new (...) SELECT ... FROM old
+                        // Only insert columns that can be mapped from the existing table (including renames).
+                        // New columns without a source are omitted so that SQLite applies column defaults.
                         const config = getTableConfig(table);
-                        const desiredCols = config.columns.map((c) => c.name);
 
-                        const selectExprs = desiredCols.map((colName) => {
+                        const insertCols: string[] = [];
+                        const selectExprs: string[] = [];
+
+                        for (const col of config.columns) {
+                            const colName = col.name;
+
                             // If old column was renamed to new name
                             const mappedOld = Object.keys(tableRenameMap).find(
                                 (old) => tableRenameMap[old] === colName,
                             );
                             if (mappedOld && existingColumns.has(mappedOld)) {
-                                return `${quoteIdentifier(mappedOld)} AS ${quoteIdentifier(colName)}`;
+                                insertCols.push(colName);
+                                selectExprs.push(`${quoteIdentifier(mappedOld)} AS ${quoteIdentifier(colName)}`);
+                                continue;
                             }
 
+                            // If column exists with the same name in the old table, copy it directly
                             if (existingColumns.has(colName)) {
-                                return `${quoteIdentifier(colName)}`;
+                                insertCols.push(colName);
+                                selectExprs.push(`${quoteIdentifier(colName)}`);
+                                continue;
                             }
 
-                            // Fallback to default value or NULL
-                            const col = config.columns.find((c) => c.name === colName);
-                            if (col && col.default !== undefined && col.default !== null) {
-                                if (typeof col.default === 'string') {
-                                    const escapedDefault = escapeSQLString(col.default);
-                                    return `'${escapedDefault}' AS ${quoteIdentifier(colName)}`;
-                                }
-                                if (typeof col.default === 'number') {
-                                    return `${col.default} AS ${quoteIdentifier(colName)}`;
-                                }
-                                if (typeof col.default === 'boolean') {
-                                    const numericBoolDefault = col.default ? 1 : 0;
-                                    return `${numericBoolDefault} AS ${quoteIdentifier(colName)}`;
-                                }
-                            }
+                            // Column does not exist in the old table; omit it from INSERT so SQLite defaults apply.
+                        }
 
-                            return `NULL AS ${quoteIdentifier(colName)}`;
-                        });
-
-                        recreateSQLs.push(
-                            `INSERT INTO ${quoteIdentifier(newTableName)} (${desiredCols.map(quoteIdentifier).join(', ')}) SELECT ${selectExprs.join(', ')} FROM ${quoteIdentifier(
-                                tableName,
-                            )}`,
-                        );
+                        if (insertCols.length > 0) {
+                            recreateSQLs.push(
+                                `INSERT INTO ${quoteIdentifier(newTableName)} (${insertCols
+                                    .map(quoteIdentifier)
+                                    .join(', ')}) SELECT ${selectExprs.join(', ')} FROM ${quoteIdentifier(tableName)}`,
+                            );
+                        }
 
                         // 3) DROP old table
                         recreateSQLs.push(`DROP TABLE ${quoteIdentifier(tableName)}`);
@@ -387,16 +387,30 @@ export async function autoMigrate(config: RuntimeMigrationConfig): Promise<{
                             `ALTER TABLE ${quoteIdentifier(newTableName)} RENAME TO ${quoteIdentifier(tableName)}`,
                         );
 
-                        // Execute recreate statements
-                        for (const sql of recreateSQLs) {
-                            if (verbose) console.log(sql);
-                            try {
-                                await driver.executeRaw(sql);
-                            } catch (error: any) {
-                                const errorMsg = `Failed destructive migration on ${tableName}: ${error.message}`;
-                                result.errors.push(errorMsg);
-                                console.error(`❌ ${errorMsg}`);
+                        // Execute recreate statements as a batch/transaction
+                        if (verbose) {
+                            console.log('Executing destructive migration as batch:');
+                            recreateSQLs.forEach((sql) => console.log(`  ${sql}`));
+                        }
+
+                        try {
+                            if (driver.executeBatch) {
+                                // Use batch for atomicity
+                                await driver.executeBatch(recreateSQLs);
+                            } else {
+                                // Fallback: execute one by one (less safe)
+                                console.warn(
+                                    '⚠️  Driver does not support executeBatch; running statements sequentially (not atomic)',
+                                );
+                                for (const sql of recreateSQLs) {
+                                    await driver.executeRaw(sql);
+                                }
                             }
+                            if (verbose) console.log(`✅ Successfully recreated table ${tableName}`);
+                        } catch (error: any) {
+                            const errorMsg = `Failed destructive migration on ${tableName}: ${error.message}`;
+                            result.errors.push(errorMsg);
+                            console.error(`❌ ${errorMsg}`);
                         }
                     }
                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ catalogs:
     postcss-simple-vars:
       specifier: ^7.0.1
       version: 7.0.1
+    prettier:
+      specifier: ^3.7.4
+      version: 3.7.4
     prisma:
       specifier: ^5.22.0
       version: 5.22.0
@@ -256,7 +259,7 @@ importers:
         version: 7.28.5(@babel/core@7.28.6)
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
+        version: 10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
       '@storybook/addon-links':
         specifier: 'catalog:'
         version: 10.2.3(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -274,13 +277,13 @@ importers:
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@typescript-eslint/eslint-plugin':
         specifier: 'catalog:'
-        version: 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 'catalog:'
-        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/ui':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18)
@@ -295,7 +298,7 @@ importers:
         version: 7.1.3(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
       eslint-plugin-storybook:
         specifier: 'catalog:'
-        version: 10.2.3(eslint@9.39.2(jiti@2.6.1))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 10.2.3(eslint@9.39.2(jiti@1.21.7))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       happy-dom:
         specifier: ^20.4.0
         version: 20.4.0
@@ -317,6 +320,9 @@ importers:
       postcss-loader:
         specifier: 'catalog:'
         version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
+      prettier:
+        specifier: 'catalog:'
+        version: 3.7.4
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -334,13 +340,13 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(@swc/core@1.13.5)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.13.5)(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       turbo:
         specifier: ^2.8.0
         version: 2.8.0
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@1.21.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack:
         specifier: ^5.104.1
         version: 5.104.1(@swc/core@1.13.5)(esbuild@0.27.2)
@@ -455,7 +461,7 @@ importers:
         version: link:../../packages/ui-tailwind
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
+        version: 10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
       '@storybook/addon-links':
         specifier: 'catalog:'
         version: 10.2.3(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -488,13 +494,13 @@ importers:
         version: 0.31.8
       eslint:
         specifier: 'catalog:'
-        version: 9.39.2(jiti@1.21.7)
+        version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: ^16.1.1
-        version: 16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       localflare:
         specifier: 'catalog:'
-        version: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
@@ -8580,6 +8586,7 @@ packages:
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.0:
@@ -16945,10 +16952,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
+  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
+      '@storybook/csf-plugin': 10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -16962,10 +16969,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
+  '@storybook/addon-docs@10.2.3(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
+      '@storybook/csf-plugin': 10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -17050,24 +17057,24 @@ snapshots:
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
+  '@storybook/csf-plugin@10.2.3(esbuild@0.25.4)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.25.4))':
     dependencies:
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.25.4
       rollup: 4.57.1
-      vite: 7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(@swc/core@1.13.5)(esbuild@0.25.4)
 
-  '@storybook/csf-plugin@10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
+  '@storybook/csf-plugin@10.2.3(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.13.5)(esbuild@0.27.2))':
     dependencies:
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.57.1
-      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(@swc/core@1.13.5)(esbuild@0.27.2)
 
   '@storybook/global@5.0.0': {}
@@ -17350,12 +17357,12 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 5.4.21(@types/node@20.19.28)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/history@1.145.7': {}
 
@@ -17624,30 +17631,14 @@ snapshots:
     dependencies:
       '@types/node': 25.1.0
 
-  '@typescript-eslint/eslint-plugin@8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.52.0
-      '@typescript-eslint/type-utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.52.0
-      eslint: 9.39.2(jiti@1.21.7)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.54.0
       eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -17656,26 +17647,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.54.0
+      eslint: 9.39.2(jiti@1.21.7)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.52.0
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.52.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -17716,25 +17723,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -17774,24 +17781,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.52.0
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -17889,7 +17896,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -17897,7 +17904,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -17918,13 +17925,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -17960,7 +17967,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@1.21.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -19246,18 +19253,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.1
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      typescript-eslint: 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19274,33 +19281,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19309,9 +19316,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19323,13 +19330,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -19339,7 +19346,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -19348,18 +19355,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/parser': 7.28.6
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 3.25.76
       zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -19367,7 +19374,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -19381,10 +19388,10 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@10.2.3(eslint@9.39.2(jiti@2.6.1))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+  eslint-plugin-storybook@10.2.3(eslint@9.39.2(jiti@1.21.7))(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@1.21.7)
       storybook: 10.2.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
@@ -20596,7 +20603,7 @@ snapshots:
       - '@types/react-dom'
       - vite
 
-  localflare-dashboard@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  localflare-dashboard@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.0.0(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@fontsource-variable/figtree': 5.2.10
@@ -20607,7 +20614,7 @@ snapshots:
       '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tailwindcss/vite': 4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tailwindcss/vite': 4.1.18(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/react-query': 5.90.12(react@19.2.4)
       '@tanstack/react-table': 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
@@ -20647,11 +20654,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  localflare@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  localflare@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       cac: 6.7.14
       localflare-core: 0.1.2
-      localflare-dashboard: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      localflare-dashboard: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       localflare-server: 0.1.2
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -21735,8 +21742,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.7.4:
-    optional: true
+  prettier@3.7.4: {}
 
   pretty-error@4.0.0:
     dependencies:
@@ -22758,6 +22764,35 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsup@8.5.1(@swc/core@1.13.5)(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.2
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.13.5
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsup@8.5.1(@swc/core@1.13.5)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
@@ -22869,13 +22904,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
+  typescript-eslint@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -23090,24 +23125,6 @@ snapshots:
       sugarss: 5.0.1(postcss@8.5.6)
       terser: 5.46.0
 
-  vite@7.3.1(@types/node@20.19.28)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.28
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      lightningcss: 1.30.2
-      sugarss: 5.0.1(postcss@8.5.6)
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
   vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
@@ -23126,7 +23143,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -23137,7 +23154,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.1.0
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 1.21.7
       lightningcss: 1.30.2
       sugarss: 5.0.1(postcss@8.5.6)
       terser: 5.46.0
@@ -23147,7 +23164,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.28)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -23185,10 +23202,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.1.0)(@vitest/ui@4.0.18)(happy-dom@20.4.0)(jiti@1.21.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -23205,7 +23222,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ catalog:
     postcss-preset-env: ^9.6.0
     postcss-preset-mantine: ^1.18.0
     postcss-simple-vars: ^7.0.1
-    prettier: ^3.0.0
+    prettier: ^3.7.4
     prisma: ^5.22.0
     react: ^19.2.4
     react-dom: ^19.2.4


### PR DESCRIPTION
This pull request introduces several improvements and safety enhancements to the OttaORM migration system and its integration with the TanStack/Cloudflare Worker app template. The key changes include the addition of environment variables and documentation for controlling destructive migrations, improved migration table safety, new tests for destructive migration flows, and code cleanups.

**Migration Safety and Controls:**

- Added `MIGRATION_ALLOW_DESTRUCTIVE` environment variable to `.env.example` and implemented logic in both `bootstrap/routes.ts` and `worker/routes/ottaorm-init.ts` to only allow destructive migrations (e.g., dropping or renaming columns/tables) when this variable is explicitly set to `'1'` or `'true'`. [[1]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aL106-R129) [[2]](diffhunk://#diff-4ddde07296749d55c77651bb06ab856ca3ea48cbb3683b0a2353d26cd2dd1e76R322-R324) [[3]](diffhunk://#diff-b19e97df65634906adb215c86e283c2341689c2dd556f19c6e6c980490db658fR54-R56)
- Documented the purpose and usage of the `MIGRATION_ALLOW_DESTRUCTIVE` flag, along with other migration-related environment variables and best practices, in both `.env.example` and `MIGRATION_QUICK_REF.md` for developer clarity. [[1]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aR18-R28) [[2]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aR38-R45) [[3]](diffhunk://#diff-6325ed9474c909dcc5fd8ebf27d3d25d81556841a3dd348492aadfa0447d894eR287-R540)

**Migration System Enhancements:**

- Updated the `autoInit` and `runAutoMigrations` APIs to accept `allowDestructive` and `renameMap` options, enabling controlled destructive migrations and column renames with data preservation. [[1]](diffhunk://#diff-8322fd9b80220fc8c55da6c859a74f5d78bf3b789a9fc8528e9892db48622b10R56-R65) [[2]](diffhunk://#diff-8322fd9b80220fc8c55da6c859a74f5d78bf3b789a9fc8528e9892db48622b10L95-R105) [[3]](diffhunk://#diff-8322fd9b80220fc8c55da6c859a74f5d78bf3b789a9fc8528e9892db48622b10L139-R152)
- Added a comprehensive test (`runtime-generator.destructive.test.ts`) that verifies both the prevention of destructive changes when not allowed and the correct execution of destructive flows (including column renames) when permitted.

**Security Improvements:**

- Hardened migration tracking by escaping single quotes in migration names and driver types to prevent SQL injection in the `_ottabase_migrations` table. [[1]](diffhunk://#diff-a07d35dc63269e64aa3062e5d28d42ef688c3cf12e1cd3cddedb24cad2a56e92R44-R47) [[2]](diffhunk://#diff-a07d35dc63269e64aa3062e5d28d42ef688c3cf12e1cd3cddedb24cad2a56e92R60-R65)

**Code and Documentation Cleanup:**

- Cleaned up and reorganized `.env.example` (removed old sections, clarified required/optional settings, and grouped related variables). [[1]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aL89-L96) [[2]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aL106-R129)
- Removed unused `DATABASE_URL` from `packages/db/.env.example`.
- Minor import order and grouping cleanups for consistency.

These changes collectively make destructive migrations safer, more transparent, and easier to control, while improving documentation and test coverage.

**References:**
- [[1]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aR18-R28) [[2]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aR38-R45) [[3]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aL89-L96) [[4]](diffhunk://#diff-9d490d0a5eeb67b9101bdd5b48398e410ec5092fc0e9c641fc7226027727f64aL106-R129) [[5]](diffhunk://#diff-6325ed9474c909dcc5fd8ebf27d3d25d81556841a3dd348492aadfa0447d894eR287-R540) [[6]](diffhunk://#diff-4ddde07296749d55c77651bb06ab856ca3ea48cbb3683b0a2353d26cd2dd1e76R322-R324) [[7]](diffhunk://#diff-b19e97df65634906adb215c86e283c2341689c2dd556f19c6e6c980490db658fL1-R7) [[8]](diffhunk://#diff-b19e97df65634906adb215c86e283c2341689c2dd556f19c6e6c980490db658fR54-R56) [[9]](diffhunk://#diff-56365241854372ba719a3c787b2264cbabe8ba535afca046f853e113abdd7717L1-L3) [[10]](diffhunk://#diff-efbcdde78d328c5bd4f6605e55f0c1a61e0aeba64a4f6401f97400dd3cbc9711R1-R140) [[11]](diffhunk://#diff-8322fd9b80220fc8c55da6c859a74f5d78bf3b789a9fc8528e9892db48622b10R56-R65) [[12]](diffhunk://#diff-8322fd9b80220fc8c55da6c859a74f5d78bf3b789a9fc8528e9892db48622b10L95-R105) [[13]](diffhunk://#diff-8322fd9b80220fc8c55da6c859a74f5d78bf3b789a9fc8528e9892db48622b10L139-R152) [[14]](diffhunk://#diff-a07d35dc63269e64aa3062e5d28d42ef688c3cf12e1cd3cddedb24cad2a56e92R44-R47) [[15]](diffhunk://#diff-a07d35dc63269e64aa3062e5d28d42ef688c3cf12e1cd3cddedb24cad2a56e92R60-R65)