### PR TITLE
Refine Brand Kit UX and separate layout routing workflow

### DIFF
--- a/apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandKitDetailPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandKitDetailPage.tsx
@@ -8,7 +8,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@ottabase/ui-shadcn';
 import {
     IconArrowLeft,
     IconBadge,
-    IconCheck,
     IconColorSwatch,
     IconPalette,
     IconPhoto,
@@ -20,7 +19,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { brandKitApi, layoutApi, type BrandKitItem } from './brand/brandApi';
+import { brandKitApi, type BrandKitItem } from './brand/brandApi';
 import { BrandKitAdvancedTab } from './brand/BrandKitAdvancedTab';
 import { BrandKitBrandTab } from './brand/BrandKitBrandTab';
 import { BrandKitColorsTab } from './brand/BrandKitColorsTab';
@@ -221,31 +220,6 @@ export function AdminBrandKitDetailPage() {
         onError: () => toast.error('Failed to delete'),
     });
 
-    const applyKitMutation = useMutation({
-        mutationFn: async () => {
-            const mappings = (await layoutApi.getMappings()) as {
-                pathPattern: string;
-                layoutTemplateId: string;
-                brandKitId: string;
-                priority?: number;
-            }[];
-            const next = (mappings ?? []).map((m) => ({
-                pathPattern: m.pathPattern,
-                layoutTemplateId: m.layoutTemplateId,
-                brandKitId: kitId!,
-                priority: m.priority ?? 0,
-            }));
-            if (next.length === 0) throw new Error('No route mappings found to update');
-            await layoutApi.putMappings({ mappings: next });
-        },
-        onSuccess: () => {
-            toast.success('Brand Kit applied to all routes');
-            queryClient.invalidateQueries({ queryKey: ['brand', 'mappings'] });
-            refresh();
-        },
-        onError: () => toast.error('Failed to apply Brand Kit to routes'),
-    });
-
     const handleSave = () => {
         const payload = {
             name: draft.name?.trim() || draft.brandName || 'New Brand Kit',
@@ -308,6 +282,15 @@ export function AdminBrandKitDetailPage() {
     const isDefaultKit = (kitForView.isDefault ?? false) || kitForView.organizationId === null;
     const saving = isNew ? createMutation.isPending : updateMutation.isPending;
 
+    const hasColorOverrides = useMemo(() => {
+        try {
+            const parsed = JSON.parse(draft.tokensJson || '{}') as { color?: unknown };
+            return Boolean(parsed.color);
+        } catch {
+            return false;
+        }
+    }, [draft.tokensJson]);
+
     return (
         <div className="space-y-6">
             <div className="flex items-center justify-between">
@@ -323,6 +306,14 @@ export function AdminBrandKitDetailPage() {
                     </Link>
                     <h1 className="text-2xl font-bold">{draft.name || kitForView.name}</h1>
                 </div>
+                {!isNew ? (
+                    <Link
+                        to="/admin/brand-engine/layouts"
+                        className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+                    >
+                        Configure layouts & route mappings
+                    </Link>
+                ) : null}
                 <div className="flex items-center gap-2">
                     {isNew || isDefaultKit ? null : (
                         <button
@@ -333,17 +324,6 @@ export function AdminBrandKitDetailPage() {
                         >
                             <IconTrash className="mr-2 h-4 w-4" />
                             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-                        </button>
-                    )}
-                    {!isNew && (
-                        <button
-                            type="button"
-                            className="inline-flex items-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent"
-                            onClick={() => applyKitMutation.mutate()}
-                            disabled={applyKitMutation.isPending}
-                        >
-                            <IconCheck className="mr-2 h-4 w-4" />
-                            {applyKitMutation.isPending ? 'Applying…' : 'Apply to all routes'}
                         </button>
                     )}
                     <button
@@ -452,7 +432,14 @@ export function AdminBrandKitDetailPage() {
 
                 {/* Realtime preview – light and dark stacked */}
                 <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
-                    <p className="text-sm font-medium text-muted-foreground">Live preview</p>
+                    <div>
+                        <p className="text-sm font-medium text-muted-foreground">Live preview</p>
+                        {hasColorOverrides ? (
+                            <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">
+                                Showing custom token colors (overrides preset).
+                            </p>
+                        ) : null}
+                    </div>
                     <div className="space-y-2">
                         <p className="text-xs font-medium text-muted-foreground">Light</p>
                         <BrandKitPreviewPanel

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandKitDetailPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandKitDetailPage.tsx
@@ -247,6 +247,15 @@ export function AdminBrandKitDetailPage() {
         if (window.confirm('Delete this Brand Kit? This cannot be undone.')) deleteMutation.mutate();
     };
 
+    const hasColorOverrides = useMemo(() => {
+        try {
+            const parsed = JSON.parse(draft.tokensJson || '{}') as { color?: unknown };
+            return Boolean(parsed.color);
+        } catch {
+            return false;
+        }
+    }, [draft.tokensJson]);
+
     if (!isNew && (isLoading || !kit)) {
         return (
             <div className="flex items-center justify-center py-12">
@@ -281,15 +290,6 @@ export function AdminBrandKitDetailPage() {
     const logoUrls = getLogoUrls({ ...kitForView, ...draft } as BrandKitItem, logoBaseUrl);
     const isDefaultKit = (kitForView.isDefault ?? false) || kitForView.organizationId === null;
     const saving = isNew ? createMutation.isPending : updateMutation.isPending;
-
-    const hasColorOverrides = useMemo(() => {
-        try {
-            const parsed = JSON.parse(draft.tokensJson || '{}') as { color?: unknown };
-            return Boolean(parsed.color);
-        } catch {
-            return false;
-        }
-    }, [draft.tokensJson]);
 
     return (
         <div className="space-y-6">

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandLayoutsPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandLayoutsPage.tsx
@@ -19,7 +19,8 @@ export function AdminBrandLayoutsPage() {
                 </Link>
                 <h1 className="text-3xl font-bold tracking-tight">Layouts & Route Mappings</h1>
                 <p className="text-muted-foreground mt-1">
-                    Define layout templates and map paths to layout + Brand Kit. Higher priority wins.
+                    Choose layout structures and map routes to Brand Kits. Start with visual presets, then fine-tune
+                    priorities.
                 </p>
             </div>
             <LayoutEditorTab />

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/brand/BrandKitThemeTab.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/brand/BrandKitThemeTab.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { getThemePresetItems } from '@ottabase/brand-engine/themes';
 import { OttaSelect, type ItemRendererProps, type OttaSelectItem } from '@ottabase/ottaselect';
-import { Label, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@ottabase/ui-shadcn';
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Label } from '@ottabase/ui-shadcn';
 
 /** Convert HSL string "221 83% 53%" or "217 91% 60% / 0.1" to CSS hsl() */
 function hslToCss(hsl: string): string {
@@ -30,8 +30,27 @@ export function BrandKitThemeTab({
     const themePresetItems = useMemo(() => getThemePresetItems(), []);
     const selectedId = themePresetId ?? 'default';
     const selectedItem = themePresetItems.find((t) => t.id === selectedId) ?? themePresetItems[0];
+    const hasCustomColorOverrides = useMemo(() => {
+        try {
+            const parsed = JSON.parse(tokensJson || '{}') as { color?: unknown };
+            return !!parsed?.color;
+        } catch {
+            return false;
+        }
+    }, [tokensJson]);
 
-    const ThemePresetRenderer = ({ item, isSelected }: ItemRendererProps) => (
+    const handleRestorePresetColors = () => {
+        try {
+            const parsed = JSON.parse(tokensJson || '{}') as Record<string, unknown>;
+            if (!parsed.color) return;
+            delete parsed.color;
+            onTokensChange(JSON.stringify(parsed, null, 2));
+        } catch {
+            // Keep the raw text untouched when invalid JSON
+        }
+    };
+
+    const ThemePresetRenderer = ({ item }: ItemRendererProps) => (
         <div className="flex flex-col gap-1.5 flex-1 min-w-0">
             <span className="truncate font-medium capitalize">{item.name}</span>
             <div className="flex gap-1 shrink-0">
@@ -53,11 +72,11 @@ export function BrandKitThemeTab({
                 <CardHeader>
                     <CardTitle>Base theme preset</CardTitle>
                     <CardDescription>
-                        Choose a preset – it fully overrides the color palette (buttons, sidebar, links). Tokens below
-                        override radius, spacing, shadow, motion only.
+                        Choose the base palette for this Brand Kit. If custom color tokens exist, they override the
+                        preset until restored.
                     </CardDescription>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-3">
                     <OttaSelect
                         mode="single"
                         items={themePresetItems}
@@ -89,6 +108,23 @@ export function BrandKitThemeTab({
                         )}
                         className="w-full"
                     />
+                    {hasCustomColorOverrides ? (
+                        <div className="rounded-md border border-amber-300/50 bg-amber-50/70 p-3 text-sm dark:border-amber-700/40 dark:bg-amber-950/20">
+                            <p className="font-medium">Custom color overrides are active</p>
+                            <p className="text-muted-foreground mt-1">
+                                The preview and app will use token color values instead of the selected preset.
+                            </p>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="mt-2"
+                                onClick={handleRestorePresetColors}
+                            >
+                                Restore preset colors
+                            </Button>
+                        </div>
+                    ) : null}
                 </CardContent>
             </Card>
 
@@ -96,7 +132,8 @@ export function BrandKitThemeTab({
                 <CardHeader>
                     <CardTitle>Design tokens JSON</CardTitle>
                     <CardDescription>
-                        Override typography, spacing, radius, shadow, motion. Color is controlled by the preset above.
+                        Override typography, spacing, radius, shadow, and motion. Add color tokens only when you
+                        intentionally want to override the preset.
                     </CardDescription>
                 </CardHeader>
                 <CardContent>

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/brand/BrandKitThemeTab.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/brand/BrandKitThemeTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { getThemePresetItems } from '@ottabase/brand-engine/themes';
+import { THEME_PRESET_ITEMS, getThemePresetItems } from '@ottabase/brand-engine';
 import { OttaSelect, type ItemRendererProps, type OttaSelectItem } from '@ottabase/ottaselect';
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Label } from '@ottabase/ui-shadcn';
 
@@ -8,8 +8,8 @@ function hslToCss(hsl: string): string {
     const base = hsl.split('/')[0].trim();
     const parts = base
         .split(/\s+/)
-        .map(Number)
-        .filter((n) => !isNaN(n));
+        .map((value) => parseFloat(value))
+        .filter((n) => !Number.isNaN(n));
     if (parts.length < 3) return 'hsl(221, 83%, 53%)';
     return `hsl(${parts[0]}, ${parts[1]}%, ${parts[2]}%)`;
 }
@@ -27,7 +27,13 @@ export function BrandKitThemeTab({
     onThemePresetChange,
     onTokensChange,
 }: BrandKitThemeTabProps) {
-    const themePresetItems = useMemo(() => getThemePresetItems(), []);
+    const themePresetItems = useMemo(() => {
+        const runtimeItems = getThemePresetItems();
+        if (runtimeItems.length <= 1) return THEME_PRESET_ITEMS;
+        const palettes = runtimeItems.map((item) => item.colors.join('|'));
+        const hasDistinctPalettes = new Set(palettes).size > 1;
+        return hasDistinctPalettes ? runtimeItems : THEME_PRESET_ITEMS;
+    }, []);
     const selectedId = themePresetId ?? 'default';
     const selectedItem = themePresetItems.find((t) => t.id === selectedId) ?? themePresetItems[0];
     const hasCustomColorOverrides = useMemo(() => {

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
@@ -74,40 +74,36 @@ function LayoutMiniPreview({ config }: { config: LayoutConfig }) {
     const hasHeader = config.header !== 'none';
 
     return (
-        <div className="space-y-2 rounded-lg border bg-background p-2.5 dark:border-muted">
-            <div className="rounded-md border bg-muted/20 p-2 dark:border-muted">
-                <div className="aspect-[16/10] rounded-md border bg-background p-2 shadow-sm dark:border-muted">
-                    <div className="flex h-full gap-1.5">
-                        {config.header === 'sidebar' ? <div className="w-2.5 rounded bg-muted" /> : null}
-                        <div className="flex flex-1 flex-col gap-1">
-                            {hasHeader && config.header !== 'sidebar' ? (
-                                <div className={`${headerHeight} rounded bg-muted`} />
-                            ) : null}
-                            {config.navigation === 'topbar' ? <div className="h-2.5 rounded bg-muted/90" /> : null}
-                            <div className="flex min-h-0 flex-1 gap-1">
-                                {config.navigation !== 'topbar' ? (
-                                    <div className={`${navWidth} relative rounded bg-muted`}>
-                                        {config.navigation === 'drawer' ? (
-                                            <div className="absolute left-1 top-2 flex flex-col gap-0.5">
-                                                <span className="h-0.5 w-3 rounded-full bg-background" />
-                                                <span className="h-0.5 w-3 rounded-full bg-background" />
-                                                <span className="h-0.5 w-3 rounded-full bg-background" />
-                                            </div>
-                                        ) : null}
-                                    </div>
-                                ) : null}
-                                <div className="flex min-h-0 flex-1 justify-center rounded bg-muted/40 p-1.5">
-                                    <div className={`flex h-full w-full ${contentMaxWidth} flex-col ${densityGap}`}>
-                                        <div className={`${blockHeight} rounded bg-background/90`} />
-                                        <div className="grid flex-1 grid-cols-2 gap-1">
-                                            <div className="rounded bg-background/90" />
-                                            <div className="rounded bg-background/90" />
+        <div className="space-y-2">
+            <div className="aspect-[16/10] rounded-md border bg-muted/10 p-2 dark:border-muted/60">
+                <div className="flex h-full gap-1.5">
+                    {config.header === 'sidebar' ? <div className="w-2.5 rounded bg-muted" /> : null}
+                    <div className="flex flex-1 flex-col gap-1">
+                        {hasHeader && config.header !== 'sidebar' ? (
+                            <div className={`${headerHeight} rounded bg-muted`} />
+                        ) : null}
+                        {config.navigation === 'topbar' ? <div className="h-2.5 rounded bg-muted/90" /> : null}
+                        <div className="flex min-h-0 flex-1 gap-1">
+                            {config.navigation !== 'topbar' ? (
+                                <div className={`${navWidth} relative rounded bg-muted`}>
+                                    {config.navigation === 'drawer' ? (
+                                        <div className="absolute left-1.5 top-2 flex flex-col gap-0.5">
+                                            <span className="h-0.5 w-3 rounded-full bg-background" />
+                                            <span className="h-0.5 w-3 rounded-full bg-background" />
+                                            <span className="h-0.5 w-3 rounded-full bg-background" />
                                         </div>
+                                    ) : null}
+                                </div>
+                            ) : null}
+                            <div className="flex min-h-0 flex-1 justify-center rounded bg-muted/40 p-1.5">
+                                <div className={`flex h-full w-full ${contentMaxWidth} flex-col ${densityGap}`}>
+                                    <div className="grid flex-1 grid-cols-1 gap-1">
+                                        <div className="rounded bg-background/90" />
                                     </div>
                                 </div>
                             </div>
-                            {config.footer ? <div className="h-2 rounded bg-muted" /> : null}
                         </div>
+                        {config.footer ? <div className="h-2 rounded bg-muted" /> : null}
                     </div>
                 </div>
             </div>

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
@@ -1,6 +1,7 @@
 import { isValidPathPattern, LAYOUT_PRESETS, type LayoutComponentKey, type LayoutConfig } from '@ottabase/brand-engine';
 import { useBrand } from '@ottabase/brand-engine-react';
 import {
+    Badge,
     Button,
     Card,
     CardContent,
@@ -24,7 +25,7 @@ import {
 } from '@ottabase/ui-shadcn';
 import { IconEdit, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { brandKitApi, layoutApi, type LayoutMappingItem, type LayoutTemplateItem } from './brandApi';
 
@@ -44,6 +45,47 @@ const DEFAULT_CONFIGS = COMPONENT_KEYS.reduce<Record<LayoutComponentKey, LayoutC
     },
     {} as Record<LayoutComponentKey, LayoutConfig>,
 );
+
+function mergeLayoutConfig(existing: object | undefined, fallback: LayoutConfig): LayoutConfig {
+    if (!existing || typeof existing !== 'object') return fallback;
+    const c = existing as Record<string, unknown>;
+    return {
+        header: (c.header as LayoutConfig['header']) ?? fallback.header,
+        navigation: (c.navigation as LayoutConfig['navigation']) ?? fallback.navigation,
+        contentWidth: (c.contentWidth as LayoutConfig['contentWidth']) ?? fallback.contentWidth,
+        footer: typeof c.footer === 'boolean' ? c.footer : fallback.footer,
+        density: (c.density as LayoutConfig['density']) ?? fallback.density,
+    };
+}
+
+function getTemplateConfig(template: LayoutTemplateItem): LayoutConfig {
+    const key = template.componentKey as LayoutComponentKey;
+    const fallback = DEFAULT_CONFIGS[key] ?? DEFAULT_CONFIGS['app-shell'];
+    return mergeLayoutConfig(template.config, fallback);
+}
+
+function LayoutMiniPreview({ config }: { config: LayoutConfig }) {
+    const headerVisible = config.header !== 'none';
+    const navWidth = config.navigation === 'sidebar' ? 'w-8' : config.navigation === 'drawer' ? 'w-5' : 'w-0';
+    return (
+        <div className="rounded border bg-background p-2 dark:border-muted">
+            <div className="h-16 rounded border bg-muted/30 p-1 dark:border-muted">
+                {headerVisible ? <div className="mb-1 h-2.5 rounded bg-muted" /> : null}
+                <div className="flex h-[calc(100%-0.5rem)] gap-1">
+                    {config.navigation !== 'topbar' ? <div className={`${navWidth} rounded bg-muted`} /> : null}
+                    <div className="flex-1 rounded bg-muted/70 p-1">
+                        {config.navigation === 'topbar' ? <div className="mb-1 h-2 rounded bg-muted" /> : null}
+                        <div className="grid h-full grid-cols-2 gap-1">
+                            <div className="rounded bg-background/70" />
+                            <div className="rounded bg-background/70" />
+                        </div>
+                    </div>
+                </div>
+                {config.footer ? <div className="mt-1 h-1.5 rounded bg-muted" /> : null}
+            </div>
+        </div>
+    );
+}
 
 function LayoutConfigEditor({ config, onChange }: { config: LayoutConfig; onChange: (c: LayoutConfig) => void }) {
     return (
@@ -164,6 +206,8 @@ export function LayoutEditorTab() {
         onError: () => toast.error('Failed to save mappings'),
     });
 
+    const layoutOptions = useMemo(() => [...BUILT_IN_PRESETS, ...templates], [templates]);
+
     if (loadingTemplates || loadingMappings || loadingKits) {
         return (
             <div className="flex items-center justify-center py-12">
@@ -178,30 +222,36 @@ export function LayoutEditorTab() {
                 <CardHeader>
                     <CardTitle>Layout templates</CardTitle>
                     <CardDescription>
-                        Built-in presets (Homepage, App Shell, Docs, Minimal) are always available. Create custom
-                        templates for more control.
+                        Built-in presets are always available. Create custom templates only when you need different
+                        structure rules.
                     </CardDescription>
                 </CardHeader>
                 <CardContent>
                     <div className="space-y-4">
                         <CreateTemplateDialog templates={templates} />
                         {templates.length === 0 ? (
-                            <p className="text-sm text-muted-foreground py-6 text-center">
-                                No custom templates yet. You can map routes to built-in presets below.
+                            <p className="py-6 text-center text-sm text-muted-foreground">
+                                No custom templates yet. Use built-in templates in route mappings below.
                             </p>
                         ) : (
-                            <div className="space-y-2">
-                                {templates.map((t) => (
-                                    <div key={t.id} className="flex items-center justify-between rounded-lg border p-4">
-                                        <div>
-                                            <span className="font-medium">{t.name}</span>
-                                            <span className="ml-2 text-xs text-muted-foreground font-mono">
-                                                {t.componentKey}
-                                            </span>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                {templates.map((t) => {
+                                    const config = getTemplateConfig(t);
+                                    return (
+                                        <div key={t.id} className="rounded-lg border p-4 dark:border-muted">
+                                            <div className="mb-3 flex items-center justify-between gap-2">
+                                                <div>
+                                                    <p className="font-medium">{t.name}</p>
+                                                    <p className="font-mono text-xs text-muted-foreground">
+                                                        {t.componentKey}
+                                                    </p>
+                                                </div>
+                                                <EditTemplateDialog template={t} />
+                                            </div>
+                                            <LayoutMiniPreview config={config} />
                                         </div>
-                                        <EditTemplateDialog template={t} />
-                                    </div>
-                                ))}
+                                    );
+                                })}
                             </div>
                         )}
                     </div>
@@ -212,14 +262,13 @@ export function LayoutEditorTab() {
                 <CardHeader>
                     <CardTitle>Route mappings</CardTitle>
                     <CardDescription>
-                        Match paths to layout + Brand Kit. Higher priority wins. Use * (one segment) and ** (rest of
-                        path). Saving replaces all mappings.
+                        Map path patterns to a layout + Brand Kit. Higher priority wins. Saving replaces all mappings.
                     </CardDescription>
                 </CardHeader>
                 <CardContent>
                     <MappingsEditor
                         mappings={mappings}
-                        layoutOptions={[...BUILT_IN_PRESETS, ...templates]}
+                        layoutOptions={layoutOptions}
                         kits={kits}
                         onSave={(m) =>
                             putMappingsMutation.mutate({
@@ -247,7 +296,6 @@ function CreateTemplateDialog({ templates }: { templates: LayoutTemplateItem[] }
     const queryClient = useQueryClient();
     const { refresh } = useBrand();
 
-    // Reset config when component changes
     useEffect(() => {
         setConfig(DEFAULT_CONFIGS[componentKey]);
     }, [componentKey]);
@@ -265,18 +313,20 @@ function CreateTemplateDialog({ templates }: { templates: LayoutTemplateItem[] }
         onError: () => toast.error('Failed to create'),
     });
 
+    const duplicateName = templates.some((t) => t.name.toLowerCase() === name.trim().toLowerCase());
+
     return (
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
                 <Button>
-                    <IconPlus className="h-4 w-4 mr-2" />
+                    <IconPlus className="mr-2 h-4 w-4" />
                     New template
                 </Button>
             </DialogTrigger>
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>Create layout template</DialogTitle>
-                    <DialogDescription>Add a layout preset with custom config for route mappings.</DialogDescription>
+                    <DialogDescription>Use this only for reusable layouts you plan to map on routes.</DialogDescription>
                 </DialogHeader>
                 <div className="space-y-4 py-4">
                     <div>
@@ -285,8 +335,9 @@ function CreateTemplateDialog({ templates }: { templates: LayoutTemplateItem[] }
                             id="layoutName"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
-                            placeholder="e.g. Main App Shell"
+                            placeholder="e.g. Marketing Shell"
                         />
+                        {duplicateName ? <p className="mt-1 text-xs text-amber-600">Name already exists.</p> : null}
                     </div>
                     <div>
                         <Label>Component</Label>
@@ -305,13 +356,7 @@ function CreateTemplateDialog({ templates }: { templates: LayoutTemplateItem[] }
                     </div>
                     <LayoutConfigEditor config={config} onChange={setConfig} />
                     <Button
-                        onClick={() =>
-                            putMutation.mutate({
-                                name: name.trim() || componentKey,
-                                componentKey,
-                                config,
-                            })
-                        }
+                        onClick={() => putMutation.mutate({ name: name.trim() || componentKey, componentKey, config })}
                         disabled={putMutation.isPending}
                     >
                         {putMutation.isPending ? 'Creating...' : 'Create'}
@@ -322,42 +367,19 @@ function CreateTemplateDialog({ templates }: { templates: LayoutTemplateItem[] }
     );
 }
 
-function mergeLayoutConfig(existing: object | undefined, fallback: LayoutConfig): LayoutConfig {
-    if (!existing || typeof existing !== 'object') return fallback;
-    const c = existing as Record<string, unknown>;
-    return {
-        header: (c.header as LayoutConfig['header']) ?? fallback.header,
-        navigation: (c.navigation as LayoutConfig['navigation']) ?? fallback.navigation,
-        contentWidth: (c.contentWidth as LayoutConfig['contentWidth']) ?? fallback.contentWidth,
-        footer: typeof c.footer === 'boolean' ? c.footer : fallback.footer,
-        density: (c.density as LayoutConfig['density']) ?? fallback.density,
-    };
-}
-
 function EditTemplateDialog({ template }: { template: LayoutTemplateItem }) {
     const [open, setOpen] = useState(false);
     const [name, setName] = useState(template.name);
     const [componentKey, setComponentKey] = useState<LayoutComponentKey>(template.componentKey as LayoutComponentKey);
-    const [config, setConfig] = useState<LayoutConfig>(() =>
-        mergeLayoutConfig(
-            template.config,
-            DEFAULT_CONFIGS[template.componentKey as LayoutComponentKey] ?? DEFAULT_CONFIGS['app-shell'],
-        ),
-    );
+    const [config, setConfig] = useState<LayoutConfig>(() => getTemplateConfig(template));
     const queryClient = useQueryClient();
     const { refresh } = useBrand();
 
     useEffect(() => {
-        if (open) {
-            setName(template.name);
-            setComponentKey(template.componentKey as LayoutComponentKey);
-            setConfig(
-                mergeLayoutConfig(
-                    template.config,
-                    DEFAULT_CONFIGS[template.componentKey as LayoutComponentKey] ?? DEFAULT_CONFIGS['app-shell'],
-                ),
-            );
-        }
+        if (!open) return;
+        setName(template.name);
+        setComponentKey(template.componentKey as LayoutComponentKey);
+        setConfig(getTemplateConfig(template));
     }, [open, template]);
 
     const putMutation = useMutation({
@@ -382,7 +404,7 @@ function EditTemplateDialog({ template }: { template: LayoutTemplateItem }) {
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>Edit layout template</DialogTitle>
-                    <DialogDescription>Change name, component, or layout config.</DialogDescription>
+                    <DialogDescription>Change the name, component, or config.</DialogDescription>
                 </DialogHeader>
                 <div className="space-y-4 py-4">
                     <div>
@@ -486,70 +508,91 @@ function MappingsEditor({
 
     return (
         <div className="space-y-4">
-            <div className="flex flex-wrap gap-2">
-                <div>
+            <div className="space-y-3 rounded-lg border p-4 dark:border-muted">
+                <div className="flex flex-wrap gap-2">
+                    <div>
+                        <Input
+                            value={pathPattern}
+                            onChange={(e) => handlePathPatternChange(e.target.value)}
+                            placeholder="/* or /admin/**"
+                            className={`max-w-[180px] ${patternError ? 'border-red-500' : ''}`}
+                        />
+                        {patternError ? <p className="mt-1 text-xs text-red-500">{patternError}</p> : null}
+                    </div>
+                    <Select value={brandKitId} onValueChange={setBrandKitId}>
+                        <SelectTrigger className="w-[220px]">
+                            <SelectValue placeholder="Brand Kit" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {kits.map((k) => (
+                                <SelectItem key={k.id} value={k.id}>
+                                    {k.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
                     <Input
-                        value={pathPattern}
-                        onChange={(e) => handlePathPatternChange(e.target.value)}
-                        placeholder="/* or /admin/**"
-                        className={`max-w-[180px] ${patternError ? 'border-red-500' : ''}`}
+                        type="number"
+                        value={priority}
+                        onChange={(e) => setPriority(Number(e.target.value) || 0)}
+                        placeholder="Priority"
+                        className="w-20"
                     />
-                    {patternError && <p className="text-xs text-red-500 mt-1">{patternError}</p>}
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={add}
+                        disabled={
+                            !pathPattern.trim() ||
+                            !!patternError ||
+                            !layoutTemplateId ||
+                            !brandKitId ||
+                            kits.length === 0
+                        }
+                    >
+                        Add mapping
+                    </Button>
                 </div>
-                <Select value={layoutTemplateId} onValueChange={setLayoutTemplateId}>
-                    <SelectTrigger className="w-[180px]">
-                        <SelectValue placeholder="Layout" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {layoutOptions.map((t) => (
-                            <SelectItem key={t.id} value={t.id}>
-                                {t.name}
-                                {BUILT_IN_PRESETS.some((p) => p.id === t.id) && (
-                                    <span className="ml-1.5 text-muted-foreground text-xs">preset</span>
-                                )}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-                <Select value={brandKitId} onValueChange={setBrandKitId}>
-                    <SelectTrigger className="w-[180px]">
-                        <SelectValue placeholder="Brand Kit" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {kits.map((k) => (
-                            <SelectItem key={k.id} value={k.id}>
-                                {k.name}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-                <Input
-                    type="number"
-                    value={priority}
-                    onChange={(e) => setPriority(Number(e.target.value) || 0)}
-                    placeholder="Priority"
-                    className="w-20"
-                />
-                <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={add}
-                    disabled={
-                        !pathPattern.trim() || !!patternError || !layoutTemplateId || !brandKitId || kits.length === 0
-                    }
-                >
-                    Add mapping
-                </Button>
+                <div>
+                    <p className="mb-2 text-sm font-medium">Select layout</p>
+                    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                        {layoutOptions.map((option) => {
+                            const selected = layoutTemplateId === option.id;
+                            const config = getTemplateConfig(option);
+                            const isPreset = BUILT_IN_PRESETS.some((p) => p.id === option.id);
+                            return (
+                                <button
+                                    key={option.id}
+                                    type="button"
+                                    onClick={() => setLayoutTemplateId(option.id)}
+                                    className={`rounded-lg border p-2 text-left transition-colors ${
+                                        selected ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'
+                                    }`}
+                                >
+                                    <div className="mb-1 flex items-center gap-2">
+                                        <p className="truncate text-sm font-medium">{option.name}</p>
+                                        {isPreset ? (
+                                            <Badge variant="secondary" className="text-[10px]">
+                                                Preset
+                                            </Badge>
+                                        ) : null}
+                                    </div>
+                                    <LayoutMiniPreview config={config} />
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
             </div>
-            {kits.length === 0 && (
+            {kits.length === 0 ? (
                 <p className="text-sm text-amber-600 dark:text-amber-500">
                     Create a Brand Kit first before adding mappings.
                 </p>
-            )}
+            ) : null}
             {items.length === 0 ? (
                 <div className="rounded-lg border border-dashed py-8 text-center dark:border-muted">
                     <p className="text-sm text-muted-foreground">No mappings yet. Add path patterns above.</p>
-                    <p className="text-xs text-muted-foreground mt-1">
+                    <p className="mt-1 text-xs text-muted-foreground">
                         Example: <code className="rounded bg-muted px-1">/blog/**</code> or{' '}
                         <code className="rounded bg-muted px-1">/admin/**</code>
                     </p>
@@ -562,7 +605,7 @@ function MappingsEditor({
                             className="flex items-center justify-between rounded border px-3 py-2 dark:border-muted"
                         >
                             <span className="font-mono text-sm">{m.pathPattern}</span>
-                            <span className="text-muted-foreground text-sm">
+                            <span className="text-sm text-muted-foreground">
                                 {layoutOptions.find((t) => t.id === m.layoutTemplateId)?.name ?? m.layoutTemplateId} →{' '}
                                 {kits.find((k) => k.id === m.brandKitId)?.name ?? m.brandKitId}
                             </span>

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
@@ -71,22 +71,30 @@ function LayoutMiniPreview({ config }: { config: LayoutConfig }) {
         config.contentWidth === 'full' ? 'max-w-none' : config.contentWidth === 'fluid' ? 'max-w-[94%]' : 'max-w-[72%]';
     const navWidth = config.navigation === 'sidebar' ? 'w-10' : config.navigation === 'drawer' ? 'w-6' : 'w-0';
     const headerHeight = config.header === 'minimal' ? 'h-3' : config.header === 'topbar' ? 'h-4' : 'h-0';
+    const hasHeader = config.header !== 'none';
 
     return (
         <div className="space-y-2 rounded-lg border bg-background p-2.5 dark:border-muted">
             <div className="rounded-md border bg-muted/20 p-2 dark:border-muted">
-                <div className="mb-2 h-1.5 w-16 rounded-full bg-muted" />
                 <div className="aspect-[16/10] rounded-md border bg-background p-2 shadow-sm dark:border-muted">
                     <div className="flex h-full gap-1.5">
                         {config.header === 'sidebar' ? <div className="w-2.5 rounded bg-muted" /> : null}
                         <div className="flex flex-1 flex-col gap-1">
-                            {config.header !== 'none' && config.header !== 'sidebar' ? (
+                            {hasHeader && config.header !== 'sidebar' ? (
                                 <div className={`${headerHeight} rounded bg-muted`} />
                             ) : null}
                             {config.navigation === 'topbar' ? <div className="h-2.5 rounded bg-muted/90" /> : null}
                             <div className="flex min-h-0 flex-1 gap-1">
                                 {config.navigation !== 'topbar' ? (
-                                    <div className={`${navWidth} rounded bg-muted`} />
+                                    <div className={`${navWidth} relative rounded bg-muted`}>
+                                        {config.navigation === 'drawer' ? (
+                                            <div className="absolute left-1 top-2 flex flex-col gap-0.5">
+                                                <span className="h-0.5 w-3 rounded-full bg-background" />
+                                                <span className="h-0.5 w-3 rounded-full bg-background" />
+                                                <span className="h-0.5 w-3 rounded-full bg-background" />
+                                            </div>
+                                        ) : null}
+                                    </div>
                                 ) : null}
                                 <div className="flex min-h-0 flex-1 justify-center rounded bg-muted/40 p-1.5">
                                     <div className={`flex h-full w-full ${contentMaxWidth} flex-col ${densityGap}`}>
@@ -104,11 +112,11 @@ function LayoutMiniPreview({ config }: { config: LayoutConfig }) {
                 </div>
             </div>
             <div className="flex flex-wrap gap-1 text-[10px] text-muted-foreground">
-                <span className="rounded bg-muted px-1.5 py-0.5">header: {config.header}</span>
-                <span className="rounded bg-muted px-1.5 py-0.5">nav: {config.navigation}</span>
                 <span className="rounded bg-muted px-1.5 py-0.5">width: {config.contentWidth}</span>
                 <span className="rounded bg-muted px-1.5 py-0.5">density: {config.density}</span>
                 <span className="rounded bg-muted px-1.5 py-0.5">footer: {config.footer ? 'on' : 'off'}</span>
+                <span className="rounded bg-muted px-1.5 py-0.5">header: {config.header}</span>
+                <span className="rounded bg-muted px-1.5 py-0.5">nav: {config.navigation}</span>
             </div>
         </div>
     );
@@ -247,70 +255,93 @@ export function LayoutEditorTab() {
         <div className="space-y-6">
             <Card>
                 <CardHeader>
-                    <CardTitle>Layout templates</CardTitle>
+                    <CardTitle>How layout routing works</CardTitle>
                     <CardDescription>
-                        Built-in presets are always available. Create custom templates only when you need different
-                        structure rules.
+                        Route mappings are the primary control; layout templates simply describe the structures you
+                        attach to those routes.
                     </CardDescription>
                 </CardHeader>
-                <CardContent>
-                    <div className="space-y-4">
-                        <CreateTemplateDialog templates={templates} />
-                        {templates.length === 0 ? (
-                            <p className="py-6 text-center text-sm text-muted-foreground">
-                                No custom templates yet. Use built-in templates in route mappings below.
-                            </p>
-                        ) : (
-                            <div className="grid gap-3 sm:grid-cols-2">
-                                {templates.map((t) => {
-                                    const config = getTemplateConfig(t);
-                                    return (
-                                        <div key={t.id} className="rounded-lg border p-4 dark:border-muted">
-                                            <div className="mb-3 flex items-center justify-between gap-2">
-                                                <div>
-                                                    <p className="font-medium">{t.name}</p>
-                                                    <p className="font-mono text-xs text-muted-foreground">
-                                                        {t.componentKey}
-                                                    </p>
-                                                </div>
-                                                <EditTemplateDialog template={t} />
-                                            </div>
-                                            <LayoutMiniPreview config={config} />
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        )}
-                    </div>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                    <ol className="space-y-1 list-decimal pl-5">
+                        <li>Define a path pattern &amp; assign the Brand Kit that should own it.</li>
+                        <li>Select a layout preset or custom template that matches the desired structure.</li>
+                        <li>Save mappings (higher priority wins) to apply the layout at runtime.</li>
+                    </ol>
                 </CardContent>
             </Card>
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>Route mappings</CardTitle>
-                    <CardDescription>
-                        Map path patterns to a layout + Brand Kit. Higher priority wins. Saving replaces all mappings.
-                    </CardDescription>
-                </CardHeader>
-                <CardContent>
-                    <MappingsEditor
-                        mappings={mappings}
-                        layoutOptions={layoutOptions}
-                        kits={kits}
-                        onSave={(m) =>
-                            putMappingsMutation.mutate({
-                                mappings: m.map(({ pathPattern, layoutTemplateId, brandKitId, priority }) => ({
-                                    pathPattern,
-                                    layoutTemplateId,
-                                    brandKitId: brandKitId!,
-                                    priority: priority ?? 0,
-                                })),
-                            })
-                        }
-                        saving={putMappingsMutation.isPending}
-                    />
-                </CardContent>
-            </Card>
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr),320px]">
+                <Card className="space-y-0">
+                    <CardHeader>
+                        <CardTitle>Route mappings</CardTitle>
+                        <CardDescription>
+                            Higher priorities win. This form builds the list of patterns that the router evaluates every
+                            request against.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <MappingsEditor
+                            mappings={mappings}
+                            layoutOptions={layoutOptions}
+                            kits={kits}
+                            onSave={(m) =>
+                                putMappingsMutation.mutate({
+                                    mappings: m.map(({ pathPattern, layoutTemplateId, brandKitId, priority }) => ({
+                                        pathPattern,
+                                        layoutTemplateId,
+                                        brandKitId: brandKitId!,
+                                        priority: priority ?? 0,
+                                    })),
+                                })
+                            }
+                            saving={putMappingsMutation.isPending}
+                        />
+                    </CardContent>
+                </Card>
+
+                <div className="space-y-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Layout templates</CardTitle>
+                            <CardDescription>
+                                Built-in presets are guaranteed, but you can clone any structure as a template to map on
+                                multiple routes.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="space-y-4">
+                                <CreateTemplateDialog templates={templates} />
+                                {templates.length === 0 ? (
+                                    <p className="py-6 text-center text-sm text-muted-foreground">
+                                        No custom templates yet. Use the built-in presets listed on the right when
+                                        creating mappings.
+                                    </p>
+                                ) : (
+                                    <div className="grid gap-3 sm:grid-cols-1">
+                                        {templates.map((t) => {
+                                            const config = getTemplateConfig(t);
+                                            return (
+                                                <div key={t.id} className="rounded-lg border p-4 dark:border-muted">
+                                                    <div className="mb-3 flex items-center justify-between gap-2">
+                                                        <div>
+                                                            <p className="font-medium">{t.name}</p>
+                                                            <p className="font-mono text-xs text-muted-foreground">
+                                                                {t.componentKey}
+                                                            </p>
+                                                        </div>
+                                                        <EditTemplateDialog template={t} />
+                                                    </div>
+                                                    <LayoutMiniPreview config={config} />
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
         </div>
     );
 }
@@ -618,29 +649,59 @@ function MappingsEditor({
             ) : null}
             {items.length === 0 ? (
                 <div className="rounded-lg border border-dashed py-8 text-center dark:border-muted">
-                    <p className="text-sm text-muted-foreground">No mappings yet. Add path patterns above.</p>
+                    <p className="text-sm text-muted-foreground">No mappings yet. Add pattern rows above.</p>
                     <p className="mt-1 text-xs text-muted-foreground">
                         Example: <code className="rounded bg-muted px-1">/blog/**</code> or{' '}
                         <code className="rounded bg-muted px-1">/admin/**</code>
                     </p>
                 </div>
             ) : (
-                <div className="space-y-2">
-                    {items.map((m, idx) => (
-                        <div
-                            key={idx}
-                            className="flex items-center justify-between rounded border px-3 py-2 dark:border-muted"
-                        >
-                            <span className="font-mono text-sm">{m.pathPattern}</span>
-                            <span className="text-sm text-muted-foreground">
-                                {layoutOptions.find((t) => t.id === m.layoutTemplateId)?.name ?? m.layoutTemplateId} →{' '}
-                                {kits.find((k) => k.id === m.brandKitId)?.name ?? m.brandKitId}
-                            </span>
-                            <Button size="sm" variant="ghost" onClick={() => remove(idx)}>
-                                <IconTrash className="h-4 w-4" />
-                            </Button>
-                        </div>
-                    ))}
+                <div className="overflow-x-auto rounded-lg border dark:border-muted">
+                    <table className="min-w-full divide-y divide-muted text-sm">
+                        <thead className="bg-muted/20">
+                            <tr>
+                                <th className="px-3 py-2 text-left font-semibold text-muted-foreground">
+                                    Path pattern
+                                </th>
+                                <th className="px-3 py-2 text-left font-semibold text-muted-foreground">Layout</th>
+                                <th className="px-3 py-2 text-left font-semibold text-muted-foreground">Brand Kit</th>
+                                <th className="px-3 py-2 text-left font-semibold text-muted-foreground">Priority</th>
+                                <th className="px-3 py-2 text-left font-semibold text-muted-foreground">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-muted bg-background">
+                            {items.map((m, idx) => {
+                                const layout = layoutOptions.find((t) => t.id === m.layoutTemplateId);
+                                const kit = kits.find((k) => k.id === m.brandKitId);
+                                return (
+                                    <tr key={`${m.pathPattern}-${idx}`}>
+                                        <td className="px-3 py-3 align-top">
+                                            <code className="font-mono text-xs text-muted-foreground">
+                                                {m.pathPattern}
+                                            </code>
+                                        </td>
+                                        <td className="px-3 py-3 align-top">
+                                            <p className="font-medium">{layout?.name ?? m.layoutTemplateId}</p>
+                                            <p className="text-xs text-muted-foreground">{layout?.componentKey}</p>
+                                        </td>
+                                        <td className="px-3 py-3 align-top">
+                                            <p className="font-medium">{kit?.name ?? m.brandKitId}</p>
+                                        </td>
+                                        <td className="px-3 py-3 align-top">
+                                            <span className="rounded bg-muted/40 px-2 py-0.5 text-[10px] font-semibold">
+                                                {m.priority ?? 0}
+                                            </span>
+                                        </td>
+                                        <td className="px-3 py-3 align-top">
+                                            <Button size="sm" variant="ghost" onClick={() => remove(idx)}>
+                                                <IconTrash className="h-4 w-4" />
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
                 </div>
             )}
             <Button onClick={() => onSave(items)} disabled={saving || kits.length === 0} className="mt-4">

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
@@ -66,7 +66,7 @@ function getTemplateConfig(template: LayoutTemplateItem): LayoutConfig {
 
 function LayoutMiniPreview({ config }: { config: LayoutConfig }) {
     const densityGap = config.density === 'compact' ? 'gap-1' : 'gap-1.5';
-    const blockHeight = config.density === 'compact' ? 'h-5' : 'h-6';
+
     const contentMaxWidth =
         config.contentWidth === 'full' ? 'max-w-none' : config.contentWidth === 'fluid' ? 'max-w-[94%]' : 'max-w-[72%]';
     const navWidth = config.navigation === 'sidebar' ? 'w-10' : config.navigation === 'drawer' ? 'w-6' : 'w-0';
@@ -410,8 +410,13 @@ function CreateTemplateDialog({ templates }: { templates: LayoutTemplateItem[] }
                     </div>
                     <LayoutConfigEditor config={config} onChange={setConfig} />
                     <Button
-                        onClick={() => putMutation.mutate({ name: name.trim() || componentKey, componentKey, config })}
-                        disabled={putMutation.isPending}
+                        onClick={() => {
+                            if (duplicateName) {
+                                return;
+                            }
+                            putMutation.mutate({ name: name.trim() || componentKey, componentKey, config });
+                        }}
+                        disabled={putMutation.isPending || duplicateName}
                     >
                         {putMutation.isPending ? 'Creating...' : 'Create'}
                     </Button>

--- a/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx
@@ -65,23 +65,50 @@ function getTemplateConfig(template: LayoutTemplateItem): LayoutConfig {
 }
 
 function LayoutMiniPreview({ config }: { config: LayoutConfig }) {
-    const headerVisible = config.header !== 'none';
-    const navWidth = config.navigation === 'sidebar' ? 'w-8' : config.navigation === 'drawer' ? 'w-5' : 'w-0';
+    const densityGap = config.density === 'compact' ? 'gap-1' : 'gap-1.5';
+    const blockHeight = config.density === 'compact' ? 'h-5' : 'h-6';
+    const contentMaxWidth =
+        config.contentWidth === 'full' ? 'max-w-none' : config.contentWidth === 'fluid' ? 'max-w-[94%]' : 'max-w-[72%]';
+    const navWidth = config.navigation === 'sidebar' ? 'w-10' : config.navigation === 'drawer' ? 'w-6' : 'w-0';
+    const headerHeight = config.header === 'minimal' ? 'h-3' : config.header === 'topbar' ? 'h-4' : 'h-0';
+
     return (
-        <div className="rounded border bg-background p-2 dark:border-muted">
-            <div className="h-16 rounded border bg-muted/30 p-1 dark:border-muted">
-                {headerVisible ? <div className="mb-1 h-2.5 rounded bg-muted" /> : null}
-                <div className="flex h-[calc(100%-0.5rem)] gap-1">
-                    {config.navigation !== 'topbar' ? <div className={`${navWidth} rounded bg-muted`} /> : null}
-                    <div className="flex-1 rounded bg-muted/70 p-1">
-                        {config.navigation === 'topbar' ? <div className="mb-1 h-2 rounded bg-muted" /> : null}
-                        <div className="grid h-full grid-cols-2 gap-1">
-                            <div className="rounded bg-background/70" />
-                            <div className="rounded bg-background/70" />
+        <div className="space-y-2 rounded-lg border bg-background p-2.5 dark:border-muted">
+            <div className="rounded-md border bg-muted/20 p-2 dark:border-muted">
+                <div className="mb-2 h-1.5 w-16 rounded-full bg-muted" />
+                <div className="aspect-[16/10] rounded-md border bg-background p-2 shadow-sm dark:border-muted">
+                    <div className="flex h-full gap-1.5">
+                        {config.header === 'sidebar' ? <div className="w-2.5 rounded bg-muted" /> : null}
+                        <div className="flex flex-1 flex-col gap-1">
+                            {config.header !== 'none' && config.header !== 'sidebar' ? (
+                                <div className={`${headerHeight} rounded bg-muted`} />
+                            ) : null}
+                            {config.navigation === 'topbar' ? <div className="h-2.5 rounded bg-muted/90" /> : null}
+                            <div className="flex min-h-0 flex-1 gap-1">
+                                {config.navigation !== 'topbar' ? (
+                                    <div className={`${navWidth} rounded bg-muted`} />
+                                ) : null}
+                                <div className="flex min-h-0 flex-1 justify-center rounded bg-muted/40 p-1.5">
+                                    <div className={`flex h-full w-full ${contentMaxWidth} flex-col ${densityGap}`}>
+                                        <div className={`${blockHeight} rounded bg-background/90`} />
+                                        <div className="grid flex-1 grid-cols-2 gap-1">
+                                            <div className="rounded bg-background/90" />
+                                            <div className="rounded bg-background/90" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {config.footer ? <div className="h-2 rounded bg-muted" /> : null}
                         </div>
                     </div>
                 </div>
-                {config.footer ? <div className="mt-1 h-1.5 rounded bg-muted" /> : null}
+            </div>
+            <div className="flex flex-wrap gap-1 text-[10px] text-muted-foreground">
+                <span className="rounded bg-muted px-1.5 py-0.5">header: {config.header}</span>
+                <span className="rounded bg-muted px-1.5 py-0.5">nav: {config.navigation}</span>
+                <span className="rounded bg-muted px-1.5 py-0.5">width: {config.contentWidth}</span>
+                <span className="rounded bg-muted px-1.5 py-0.5">density: {config.density}</span>
+                <span className="rounded bg-muted px-1.5 py-0.5">footer: {config.footer ? 'on' : 'off'}</span>
             </div>
         </div>
     );


### PR DESCRIPTION
### Motivation
- Separate Brand Kit (identity: logo, colors, fonts, spacing) from layout + route mapping so teams can mix-and-match brand + layout independently.
- Make layout selection more intuitive with a lightweight visual preview and clearer copy to improve admin UX and reduce accidental cross-impact.
- Surface correctness: custom color tokens should visibly take precedence in previews and be reversible with a single action.

### Description
- Focus Brand Kit detail on identity editing and remove the direct "apply to all routes" coupling, replacing it with a link to the dedicated Layouts & Route Mappings page for mapping work (`AdminBrandKitDetailPage.tsx`).
- Add detection for `tokensJson.color` overrides, surface an inline notice in the Theme tab, and provide a one-click `Restore preset colors` action that deletes the `color` block from the tokens JSON (`BrandKitThemeTab.tsx`).
- Show live-preview messaging in the Brand Kit preview panel when custom token colors are present so editors know which values are active (`AdminBrandKitDetailPage.tsx`).
- Rework layout templates & mappings UI with a compact visual "mini preview" for each layout preset/template, reorganize template listing into card/grid view, and simplify mapping controls to make selecting a layout more intuitive (`LayoutEditorTab.tsx` and `AdminBrandLayoutsPage.tsx`).
- Minor DX improvements and copy tweaks (placeholders, helper text), and defensive JSON parsing around tokens to avoid crashing on invalid text.

Affected files:
- `apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandKitDetailPage.tsx`
- `apps/ottabase-template-app-tanstack/src/pages/admin/AdminBrandLayoutsPage.tsx`
- `apps/ottabase-template-app-tanstack/src/pages/admin/brand/BrandKitThemeTab.tsx`
- `apps/ottabase-template-app-tanstack/src/pages/admin/brand/LayoutEditorTab.tsx`

### Testing
- Ran Prettier formatting check with `pnpm prettier --check <files>` which passed for the modified files.
- Ran TypeScript checks with `pnpm --filter @ottabase/ottabase-template-app-tanstack type-check` which failed due to broader workspace/module-resolution issues in this environment unrelated to these edits (reported and intentionally out-of-scope for this change).
- Attempted to start local dev preview with `pnpm --filter @ottabase/ottabase-template-app-tanstack exec vite --host 0.0.0.0 --port 4173` and to capture a screenshot via Playwright, but the environment produced package-entry resolution errors and a Chromium crash so a runtime screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa4e092dc8331a64e551a7efb2f0b)