### PR TITLE
Docs: Refactor Documentation and CLI tooling for Cloudflare setup

### DIFF
--- a/CLOUDFLARE_CONFIGURATION_GUIDE.md
+++ b/CLOUDFLARE_CONFIGURATION_GUIDE.md
@@ -192,7 +192,7 @@ multi-app: same placeholder name = shared resource; different names = isolated (
 }
 ```
 
-### 3. `apps/ottabase-template-app-tanstack/types/cloudflare.d.ts`
+### 2. `apps/ottabase-template-app-tanstack/types/cloudflare.d.ts`
 
 **Status:** ✅ Already configured
 
@@ -225,7 +225,7 @@ export interface CloudflareEnv {
 }
 ```
 
-### 4. `apps/ottabase-template-app-tanstack/cloudflare-worker.ts`
+### 3. `apps/ottabase-template-app-tanstack/cloudflare-worker.ts`
 
 **Status:** ✅ Already configured
 
@@ -242,22 +242,24 @@ export { RealtimeActor } from '@ottabase/cf-realtime/server';
 
 ### Using Drizzle with D1
 
-The app uses `@ottabase/db` package with Drizzle adapter for D1.
+The app uses `@ottabase/db` package with Drizzle adapter for D1. Access `env` directly from your Worker fetch handler:
 
 ```typescript
-import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { createD1Driver } from '@ottabase/db/drizzle-d1';
+import { setDriver } from '@ottabase/ottaorm';
 
-export async function GET() {
-    const { env } = await getCloudflareContext();
+// cloudflare-worker.ts
+export default {
+    async fetch(request: Request, env: CloudflareEnv) {
+        const driver = createD1Driver(env.OBCF_D1);
+        setDriver(driver);
 
-    const driver = createD1Driver(env.OBCF_D1);
-    const db = driver.getDb();
+        const db = driver.getDb();
+        const users = await db.select().from(usersTable);
 
-    const users = await db.select().from(usersTable);
-
-    return Response.json(users);
-}
+        return Response.json(users);
+    },
+};
 ```
 
 ---
@@ -285,22 +287,7 @@ export const authConfig = createOttabaseAuthConfig({
 });
 ```
 
-### 4. Configure Auth
-
-```typescript
-// app/auth.ts
-import { createOttabaseAuthConfig, createGoogleProvider } from '@ottabase/auth';
-
-export const authConfig = createOttabaseAuthConfig({
-    d1: env.OBCF_D1,
-    providers: [
-        createGoogleProvider(env),
-        // Add more providers
-    ],
-});
-```
-
-### 5. Set Environment Variables
+### 3. Set Environment Variables
 
 Add to `.env.local`:
 
@@ -318,7 +305,7 @@ AUTH_GOOGLE_SECRET=your-google-client-secret
 
 - [ ] **Cloudflare Resources Created**
     - [ ] D1 Database exists: `wrangler d1 list`
-    - [ ] KV Namespace exists: `wrangler kv:namespace list`
+    - [ ] KV Namespace exists: `wrangler kv namespace list`
     - [ ] R2 Bucket exists: `wrangler r2 bucket list`
     - [ ] Queue exists: `wrangler queues list`
 
@@ -359,28 +346,26 @@ curl https://your-app.workers.dev/api/cloudflare/r2/list
 
 ## 🔍 Accessing Cloudflare Bindings in Code
 
-### App Router (Server Components & Route Handlers)
+### Cloudflare Worker (Fetch Handler)
 
 ```typescript
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+// cloudflare-worker.ts
+export default {
+    async fetch(request: Request, env: CloudflareEnv) {
+        // Access bindings with OBCF_* names
+        const db = env.OBCF_D1; // D1 Database
+        const kv = env.OBCF_KV; // KV Namespace
+        const r2 = env.OBCF_R2; // R2 Bucket
+        const queue = env.OBCF_QUEUE; // Queue
+        const realtime = env.OBCF_REALTIME; // Durable Object
 
-export async function GET() {
-    const { env } = await getCloudflareContext();
-
-    // Access bindings with OBCF_* names
-    const db = env.OBCF_D1; // D1 Database
-    const kv = env.OBCF_KV; // KV Namespace
-    const r2 = env.OBCF_R2; // R2 Bucket
-    const queue = env.OBCF_QUEUE; // Queue
-    const realtime = env.OBCF_REALTIME; // Durable Object
-
-    // Use with @ottabase packages
-    // D1 via OttaORM (preferred):
-    // import { createD1Driver } from '@ottabase/db/drizzle-d1';
-    // const driver = createD1Driver(db); setDriver(driver);
-    const kvClient = createKVClient({ namespace: kv });
-    const r2Client = createR2Client({ bucket: r2 });
-}
+        // D1 via OttaORM (preferred):
+        // import { createD1Driver } from '@ottabase/db/drizzle-d1';
+        // const driver = createD1Driver(db); setDriver(driver);
+        const kvClient = createKVClient({ namespace: kv });
+        const r2Client = createR2Client({ bucket: r2 });
+    },
+};
 ```
 
 ### Package Usage

--- a/CLOUDFLARE_DEPLOY.md
+++ b/CLOUDFLARE_DEPLOY.md
@@ -219,7 +219,7 @@ wrangler d1 execute ottabase-db --remote --command="SELECT * FROM User LIMIT 5"
 
 # List resources
 wrangler d1 list
-wrangler kv:namespace list
+wrangler kv namespace list
 wrangler r2 bucket list
 wrangler queues list
 ```

--- a/README.md
+++ b/README.md
@@ -8,25 +8,47 @@ Durable Objects.
 ```
 ottabase/
 ├── apps/
-│   └── ottabase-template-app-tanstack/  # TanStack Router + Vite + Workers (primary)
+│   ├── ottabase-template-app-tanstack/       # TanStack Router + Vite + Workers (primary)
+│   └── ottabase-template-app-nextjs-homepage/ # Next.js + OpenNext (homepage/landing)
 ├── packages/
-│   ├── ottaorm/       # Fat models, auto-migrations, CRUD
-│   ├── db/            # Drizzle D1 driver
-│   ├── cf/            # Cloudflare bindings (D1, KV, R2, Queues)
-│   ├── queue/         # Job queue (Laravel-style dispatch/handlers)
-│   ├── auth/          # Auth.js v5 with D1
-│   ├── rbac/          # Role-based access control with KV caching
-│   ├── audit/         # Audit logging middleware & utilities
-│   ├── logger/        # Structured logging with context
-│   ├── state/         # Global state (Jotai)
-│   ├── ui-shadcn/     # shadcn/ui components
-│   ├── ui-mantine/    # Mantine provider + themes
-│   ├── ottaupload/    # File uploads (R2, CF Images)
-│   ├── ottaeditor/    # EditorJS wrapper
-│   ├── cf-realtime/   # WebSocket pub/sub (Durable Objects)
-│   ├── shortlinks/    # URL shortener schema
-│   ├── referrals/     # Referral tracking
-│   └── utils/         # Utilities (timezone, string, file, etc.)
+│   ├── ottaorm/          # Fat models, auto-migrations, CRUD, RLS
+│   ├── db/               # Drizzle D1 driver
+│   ├── cf/               # Cloudflare bindings (D1, KV, R2, Queues, Cache Keys)
+│   ├── cf-realtime/      # WebSocket pub/sub (Durable Objects)
+│   ├── queue/            # Job queue (dispatch, handlers, priority)
+│   ├── auth/             # Auth.js v5 with D1
+│   ├── rbac/             # Role-based access control with KV caching
+│   ├── audit/            # Audit logging with change tracking
+│   ├── analytics/        # Cloudflare Analytics Engine (WAE)
+│   ├── notifications/    # Multi-channel notifications (email, WebSocket)
+│   ├── shortlinks/       # URL shortener with interstitial + WAE tracking
+│   ├── referrals/        # Referral tracking (first-touch, WAE)
+│   ├── brand-engine/     # Design tokens, preset expansion, CSS injection
+│   ├── brand-engine-react/ # BrandProvider, LayoutResolver, useBrand()
+│   ├── ottalayout/       # Layout types, presets, path resolver, React slots
+│   ├── ottablog/         # Blog/CMS (Post, Category, Tag, Series, Studio)
+│   ├── email/            # Email sending (Resend, SES, MailChannels, SMTP)
+│   ├── cron/             # Cron handlers (static + DB scheduler)
+│   ├── logger/           # Structured logging (multi-transport)
+│   ├── config/           # App config, env vars, storage keys
+│   ├── scripts/          # CLI: cf:setup, cf:validate, cf:login, clean:*, db:*
+│   ├── state/            # Jotai atoms (theme, user, sidebar)
+│   ├── ui-shadcn/        # shadcn/ui components
+│   ├── ui-mantine/       # Mantine provider + themes
+│   ├── ui-components/    # Shared components (DarkModeToggle, Logo)
+│   ├── ui-code-highlight/ # Code syntax highlighting
+│   ├── ui-split-pane/    # Resizable split pane
+│   ├── ottaeditor/       # EditorJS wrapper with 15+ plugins
+│   ├── ottaupload/       # File uploads (R2, CF Images)
+│   ├── ottarenderer/     # EditorJS block renderer
+│   ├── ottaselect/       # Headless select/combobox
+│   ├── cropper/          # Vanilla JS image cropper (~3-4 KB)
+│   ├── spotlight/        # Command palette
+│   ├── docs/             # Markdown doc viewer
+│   ├── forms/            # Auto-generated CRUD forms from OttaORM models
+│   ├── i18n/             # i18next wrapper (en, es, fr, de)
+│   ├── api/              # Type-safe fetch wrapper
+│   └── utils/            # Timezone, string, file, URL utilities
 └── turbo.json
 ```
 
@@ -164,43 +186,69 @@ createTodo.mutate({ title: 'New Todo' });
 
 ## Packages
 
-### Database & ORM
+### Database, Auth & Infrastructure
 
-| Package             | Purpose                                                                  |
-| ------------------- | ------------------------------------------------------------------------ |
-| `@ottabase/ottaorm` | Fat models, CRUD, relationships, auto-migrations                         |
-| `@ottabase/db`      | Drizzle D1 driver (`createD1Driver`)                                     |
-| `@ottabase/cf`      | D1, KV, R2, Queues, Rate Limiting, Cache Keys, read-through cache        |
-| `@ottabase/queue`   | Job queue system (dispatch, handlers, deduplication, chaining, priority) |
-| `@ottabase/auth`    | Auth.js v5 with D1 adapter                                               |
-| `@ottabase/rbac`    | Role-based access control with per-org KV caching                        |
-| `@ottabase/audit`   | Audit logging middleware with event tracking                             |
-| `@ottabase/logger`  | Structured logging with context (replaces console.log)                   |
+| Package               | Purpose                                                                  |
+| --------------------- | ------------------------------------------------------------------------ |
+| `@ottabase/ottaorm`   | Fat models, CRUD, relationships, RLS, auto-migrations                    |
+| `@ottabase/db`        | Drizzle D1 driver (`createD1Driver`)                                     |
+| `@ottabase/cf`        | D1, KV, R2, Queues, Rate Limiting, Cache Keys, read-through KV cache     |
+| `@ottabase/queue`     | Job queue (dispatch, handlers, deduplication, chaining, priority)        |
+| `@ottabase/auth`      | Auth.js v5 with D1 adapter, OAuth, Credentials, Magic Link               |
+| `@ottabase/rbac`      | Role-based access control with per-org KV caching                        |
+| `@ottabase/audit`     | Audit logging with change tracking and RBAC context                      |
+| `@ottabase/logger`    | Structured logging (Console, HTTP, Sentry, Memory, Buffer transports)    |
+| `@ottabase/analytics` | Cloudflare Analytics Engine (WAE) — write events, query, funnel, top-K  |
+| `@ottabase/config`    | App config, env vars, storage key utilities                              |
+| `@ottabase/cron`      | Cron handlers — static code-defined and DB scheduler (Laravel-style)     |
+| `@ottabase/scripts`   | CLI tools: `cf:login`, `cf:setup`, `cf:validate`, `clean:*`, `db:*`     |
 
-### UI
+### UI Components
 
-| Package                | Purpose                               |
-| ---------------------- | ------------------------------------- |
-| `@ottabase/ui-shadcn`  | shadcn/ui components, ShadcnProviders |
-| `@ottabase/ui-mantine` | Mantine provider, pre-built themes    |
-| `@ottabase/ui-base`    | Framework-agnostic base styles        |
-| `@ottabase/ottaeditor` | EditorJS with 15 plugins              |
-| `@ottabase/ottaupload` | File upload (R2, CF Images)           |
+| Package                       | Purpose                                                  |
+| ----------------------------- | -------------------------------------------------------- |
+| `@ottabase/ui-shadcn`         | shadcn/ui components, ShadcnProviders                    |
+| `@ottabase/ui-mantine`        | Mantine provider, pre-built themes                       |
+| `@ottabase/ui-base`           | Framework-agnostic base styles                           |
+| `@ottabase/ui-components`     | Shared components: DarkModeToggle, Logo                  |
+| `@ottabase/ui-code-highlight` | Code syntax highlighting (Prism/Shiki)                   |
+| `@ottabase/ui-split-pane`     | Resizable split-pane layout component                    |
+| `@ottabase/ottaeditor`        | EditorJS wrapper with 15+ plugins (Spoiler, CTA, Review) |
+| `@ottabase/ottaupload`        | File upload component (R2, Cloudflare Images)            |
+| `@ottabase/ottarenderer`      | EditorJS block renderer for React                        |
+| `@ottabase/ottaselect`        | Headless select/combobox component                       |
+| `@ottabase/cropper`           | Vanilla JS image cropper (~3-4 KB, zero deps)            |
+| `@ottabase/spotlight`         | Spotlight/command palette component                      |
+| `@ottabase/docs`              | Markdown doc viewer with layout themes                   |
+| `@ottabase/forms`             | Auto-generated CRUD forms from OttaORM models            |
 
-### State & Utils
+### Brand, Layout & Content
 
-| Package           | Purpose                                    |
-| ----------------- | ------------------------------------------ |
-| `@ottabase/state` | Jotai atoms (theme, user, sidebar)         |
-| `@ottabase/utils` | timezone, string, file, url, git utilities |
+| Package                         | Purpose                                                                |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `@ottabase/brand-engine`        | Design tokens, preset expansion, CSS injection, email branding         |
+| `@ottabase/brand-engine-react`  | `BrandProvider`, `LayoutResolver`, `useBrand()` React bindings         |
+| `@ottabase/ottalayout`          | Layout types, 10 presets, path resolver, React slots, LayoutMeta       |
+| `@ottabase/ottablog`            | Blog/CMS models (Post, Category, Tag, Series, Version) + Blog Studio   |
 
-### Features
+### Features & Realtime
 
-| Package                 | Purpose                             |
-| ----------------------- | ----------------------------------- |
-| `@ottabase/shortlinks`  | URL shortener schema + model        |
-| `@ottabase/referrals`   | Referral tracking system            |
-| `@ottabase/cf-realtime` | WebSocket pub/sub (Durable Objects) |
+| Package                 | Purpose                                                  |
+| ----------------------- | -------------------------------------------------------- |
+| `@ottabase/cf-realtime` | WebSocket pub/sub via Durable Objects (Pusher alternative) |
+| `@ottabase/shortlinks`  | URL shortener: short codes, interstitial, expiry, WAE clicks |
+| `@ottabase/referrals`   | Referral tracking — first-touch attribution, WAE clicks  |
+| `@ottabase/notifications` | Multi-channel notifications (email, WebSocket, system)  |
+
+### Utilities & Integrations
+
+| Package           | Purpose                                               |
+| ----------------- | ----------------------------------------------------- |
+| `@ottabase/state` | Jotai atoms (theme, user, sidebar, org)               |
+| `@ottabase/utils` | Timezone, string, file, URL, git utilities            |
+| `@ottabase/api`   | Type-safe fetch wrapper with deduping and error types |
+| `@ottabase/email` | Email sending (Resend, SES, MailChannels, Nodemailer) |
+| `@ottabase/i18n`  | i18next wrapper (en, es, fr, de)                      |
 
 ## Multi-App Database Sharing
 
@@ -243,11 +291,22 @@ All models include a nullable `appId` column:
 
 ## Creating New Apps
 
+**Full-stack SPA** (TanStack Router, OttaORM, Auth, RBAC, all CF bindings):
+
 ```bash
 cp -r apps/ottabase-template-app-tanstack apps/my-app
 cd apps/my-app
 # Update package.json name
-# Delete src/pages/demo/
+# Delete src/pages/demo/  (optional — remove demo pages)
+```
+
+**Marketing homepage** (Next.js, OpenNext, Brand Engine):
+
+```bash
+cp -r apps/ottabase-template-app-nextjs-homepage apps/my-homepage
+cd apps/my-homepage
+# Update package.json name
+# Edit config/brand.config.ts to customize theme
 ```
 
 ## Package Fat Model Pattern

--- a/apps/ottabase-template-app-nextjs-homepage/README.md
+++ b/apps/ottabase-template-app-nextjs-homepage/README.md
@@ -1,32 +1,27 @@
 # Ottabase Next.js Homepage Template
 
-A barebone Next.js homepage template with OpenNext and Cloudflare Workers deployment. Perfect for creating beautiful,
-dynamic homepages with modern web technologies.
+A barebone Next.js homepage template with OpenNext and Cloudflare Workers deployment. Perfect for marketing homepages,
+landing pages, and company websites.
 
-## ✨ Features
+## Features
 
-- **Next.js 16** with App Router and React Server Components
+- **Next.js App Router** with React Server Components
 - **OpenNext** for seamless Cloudflare Workers deployment
-- **Brand Engine** - Configuration-driven theming with 8+ built-in presets
+- **Brand Engine** — Configuration-driven theming with 8+ built-in presets
 - **TypeScript** for type safety
 - **Tailwind CSS** for rapid styling
 - **Dark Mode** support out of the box
 - **Fully Responsive** design
-- **Production Ready** configuration
 
-## 🚀 Quick Start
+## Quick Start
 
 ```bash
-# Install dependencies
 pnpm install
-
-# Start dev server
 pnpm dev
-
 # Visit http://localhost:3000
 ```
 
-## 📦 Project Structure
+## Project Structure
 
 ```
 apps/ottabase-template-app-nextjs-homepage/
@@ -45,26 +40,27 @@ apps/ottabase-template-app-nextjs-homepage/
 └── next.config.js            # Next.js configuration
 ```
 
-## 🎨 Brand Customization
+## Brand Customization
 
-This template includes Brand Engine integration for easy theming. Edit `config/brand.config.ts` to customize your brand:
+Edit `config/brand.config.ts` to set your theme preset and color overrides:
 
 ```typescript
+import type { BrandTheme } from '@ottabase/brand-engine';
+
 // config/brand.config.ts
 export const brandConfig: Partial<BrandTheme> = {
     name: 'my-brand',
     // Customize colors, typography, spacing, etc.
 };
 
-// Choose from built-in presets
+// Choose from 8 built-in presets:
+// 'default', 'neo', 'crisp', 'funky', 'artisan', 'midnight', 'rose', 'verdant'
 export const themePreset = 'default';
-// Available: 'default', 'neo', 'crisp', 'funky', 'artisan', 'midnight', 'rose', 'verdant'
 ```
 
-The Brand Engine is integrated at the worker level, so themes are automatically registered and available throughout your
-app.
+The Brand Engine registers and applies the theme at the worker level via CSS custom properties.
 
-## 🛠️ Scripts
+## Scripts
 
 | Command           | Description                                    |
 | ----------------- | ---------------------------------------------- |
@@ -76,142 +72,70 @@ app.
 | `pnpm test`       | Run tests                                      |
 | `pnpm lint`       | Run ESLint                                     |
 
-## 🌐 Deployment
+## Deployment
 
 ### Local Development
 
+No Cloudflare account needed for local development:
+
 ```bash
-# No Cloudflare account needed for local development
 pnpm dev
 ```
 
 ### Production Deployment
 
-#### 1. Login to Cloudflare
-
 ```bash
 pnpm wrangler login
-```
-
-#### 2. Deploy
-
-```bash
-# Build and deploy to Cloudflare Workers
 pnpm deploy
 ```
 
 Your app will be deployed to `https://ottabase-template-app-nextjs-homepage.your-subdomain.workers.dev`
 
-### CI/CD Deployment
+### CI/CD
 
-The template includes GitHub Actions workflow support. Configure the following secrets in your repository:
+Configure these secrets in your GitHub repository for automatic deployments on push to main:
 
-- `CLOUDFLARE_API_TOKEN` - Your Cloudflare API token
-- `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID
+- `CLOUDFLARE_API_TOKEN` — API token with Edit Workers permissions
+- `CLOUDFLARE_ACCOUNT_ID` — Your Cloudflare account ID
 
-The app will be automatically deployed when changes are pushed to the main branch.
+## Customization
 
-## 📝 Customization Guide
+### Update Content
 
-### 1. Update Content
+- `app/page.tsx` — Homepage content
+- `app/about/page.tsx` — About page content
+- `app/layout.tsx` — Site metadata (title, description, etc.)
 
-Edit the following files to customize your homepage:
-
-- `app/page.tsx` - Homepage content
-- `app/about/page.tsx` - About page content
-- `app/layout.tsx` - Site metadata (title, description, etc.)
-
-### 2. Configure Brand
-
-Edit `config/brand.config.ts` to set your brand theme:
-
-```typescript
-export const themePreset = 'neo'; // Choose your preset
-```
-
-### 3. Add New Pages
-
-Create new pages in the `app/` directory:
+### Add New Pages
 
 ```bash
-# Create a new page
 mkdir -p app/contact
 echo "export default function Contact() { return <div>Contact</div> }" > app/contact/page.tsx
 ```
 
-### 4. Update Metadata
-
-Edit `app/layout.tsx` to update site metadata:
+### Update Metadata
 
 ```typescript
+// app/layout.tsx
 export const metadata: Metadata = {
     title: 'Your Site Title',
     description: 'Your site description',
-    // ... more metadata
 };
 ```
 
-## 🔧 Configuration
+## Configuration Notes
 
-### Next.js Configuration
+- **Next.js standalone output** — Used for optimal Cloudflare Workers deployment (see `next.config.js`)
+- **OpenNext** — Converts Next.js output to Cloudflare Workers format (see `open-next.config.ts`)
+- **wrangler.jsonc** — Cloudflare Workers config with asset serving and compatibility flags
 
-The template uses Next.js standalone output mode for optimal Cloudflare Workers deployment. See `next.config.js` for
-configuration details.
+## Related Templates
 
-### OpenNext Configuration
+- [Ottabase Template App (TanStack)](../ottabase-template-app-tanstack) — Full-featured SPA with OttaORM, Auth, RBAC, and
+  all Cloudflare bindings
 
-OpenNext converts Next.js apps to Cloudflare Workers format. The configuration is in `open-next.config.ts`.
+## Documentation
 
-### Wrangler Configuration
-
-Cloudflare Workers configuration is in `wrangler.jsonc`. The template includes:
-
-- Asset serving
-- Environment variables
-- Compatibility flags for Node.js APIs
-
-## 🎯 Use Cases
-
-This template is perfect for:
-
-- Marketing homepages
-- Product landing pages
-- Portfolio websites
-- Company websites
-- Documentation homepages
-- Project showcase pages
-
-## 🧪 Testing
-
-```bash
-# Run tests
-pnpm test
-
-# Run tests with coverage
-pnpm test:coverage
-```
-
-## 📚 Documentation
-
-- [Next.js Documentation](https://nextjs.org/docs)
+- [Brand Engine](../../packages/brand-engine/README.md)
 - [OpenNext Documentation](https://opennext.js.org/)
 - [Cloudflare Workers Documentation](https://developers.cloudflare.com/workers/)
-- [Brand Engine Documentation](../../packages/brand-engine/README.md)
-- [Tailwind CSS Documentation](https://tailwindcss.com/docs)
-
-## 🤝 Contributing
-
-This template is part of the Ottabase monorepo. For contributions, please refer to the main repository guidelines.
-
-## 📄 License
-
-Open Source - See the main repository for license details.
-
-## 🔗 Related Templates
-
-- [Ottabase Template App (TanStack)](../ottabase-template-app-tanstack) - Full-featured SPA template
-- [Ottabase Template App](../ottabase-template-app) - Legacy Next.js template (deprecated)
-
----
-
-**Built with ❤️ by the Ottabase team**

--- a/apps/ottabase-template-app-tanstack/README.md
+++ b/apps/ottabase-template-app-tanstack/README.md
@@ -364,31 +364,34 @@ pnpm dev:worker
 
 #### 1. Create Cloudflare Resources
 
+Use the automated setup script (recommended):
+
 ```bash
-# Login
+pnpm cf:login   # authenticate
+pnpm cf:setup   # creates D1, KV, R2, Queue — prints IDs for GitHub Secrets
+pnpm cf:validate
+```
+
+Or manually:
+
+```bash
 pnpm wrangler login
-
-# Create D1 database
 pnpm wrangler d1 create ottabase-db
-
-# Create KV namespace
-pnpm wrangler kv:namespace create OTTABASE_KV
-
-# Create R2 bucket
+pnpm wrangler kv namespace create OBCF_KV
 pnpm wrangler r2 bucket create ottabase-bucket
-
-# Create Queue
 pnpm wrangler queues create ottabase-queue
 ```
 
-#### 2. Update wrangler.jsonc
+#### 2. Set GitHub Secrets
 
-Update the IDs in `wrangler.jsonc` with your actual:
+`wrangler.jsonc` uses `ALL_CAPS` placeholder values that CI auto-substitutes from GitHub Secrets at deploy time.
+Set these in your repository → Settings → Secrets → Actions:
 
-- D1 database ID
-- KV namespace ID
-- R2 bucket name
-- Queue name
+- `D1_DATABASE_ID`, `KV_NAMESPACE_ID` (production)
+- `D1_PREVIEW_DATABASE_ID`, `KV_PREVIEW_NAMESPACE_ID` (PR previews)
+- `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
+
+See [CLOUDFLARE_DEPLOY.md](../../CLOUDFLARE_DEPLOY.md) for the full setup guide.
 
 #### 3. Analytics (optional)
 

--- a/packages/brand-engine-react/README.md
+++ b/packages/brand-engine-react/README.md
@@ -1,8 +1,17 @@
 # @ottabase/brand-engine-react
 
-React bindings for Ottabase Brand Engine.
+React bindings for Ottabase Brand Engine — brand config provider, theme application, and layout resolution.
 
-## Usage
+## Install
+
+```bash
+pnpm add @ottabase/brand-engine-react
+```
+
+## BrandProvider + useBrand
+
+`BrandProvider` fetches brand config from your API, applies the theme as CSS custom properties, and exposes it via
+context. Wrap your app root with it:
 
 ```tsx
 import { BrandProvider, useBrand } from '@ottabase/brand-engine-react';
@@ -16,12 +25,90 @@ function App() {
 }
 
 function MyContent() {
-    const { config, isLoading } = useBrand();
+    const { config, isLoading, error } = useBrand();
+    if (isLoading) return <div>Loading...</div>;
     return config ? <div>{config.brandName}</div> : null;
 }
 ```
 
-## API
+**`useBrand()` returns:**
 
-- **BrandProvider** – Fetches brand config from API, applies theme, injects custom CSS
-- **useBrand()** – Consumes brand config from context
+| Field       | Type                 | Description                     |
+| ----------- | -------------------- | ------------------------------- |
+| `config`    | `BrandConfig\|null`  | Resolved brand config for route |
+| `isLoading` | `boolean`            | True during initial fetch       |
+| `error`     | `Error\|null`        | Fetch/parse error if any        |
+| `refresh`   | `() => void`         | Manually re-fetch brand config  |
+
+**`BrandProvider` props:**
+
+- `apiEndpoint` — API path to fetch brand config from (e.g. `"/api/brand"`)
+- `appId` — App identifier passed to the API
+- `initialConfig` — Pre-fetched config for SSR/SSG (skips client fetch)
+- `fallbackTheme` — Theme tokens used if the API fails (graceful degradation)
+- `mode` — `'light'` | `'dark'` override (default: matches `prefers-color-scheme`)
+
+## LayoutResolver
+
+`LayoutResolver` reads route mappings from the brand config and renders the correct layout shell for the current path.
+Must be inside `BrandProvider`.
+
+```tsx
+import { LayoutResolver } from '@ottabase/brand-engine-react';
+import { tanstackRouterAdapter } from '@ottabase/brand-engine-react/routers';
+import type { LayoutComponentProps } from '@ottabase/brand-engine-react';
+
+// Your layout shell — receives the resolved LayoutConfig
+function AppShell({ config, children }: LayoutComponentProps) {
+    return (
+        <div className={config.navigation === 'sidebar' ? 'with-sidebar' : ''}>
+            <header>...</header>
+            <main>{children}</main>
+        </div>
+    );
+}
+
+function App() {
+    return (
+        <BrandProvider apiEndpoint="/api/brand" appId="my-app">
+            <LayoutResolver layoutComponent={AppShell} router={tanstackRouterAdapter}>
+                <RouterOutlet />
+            </LayoutResolver>
+        </BrandProvider>
+    );
+}
+```
+
+**Router adapters:**
+
+```typescript
+// TanStack Router (built-in adapter)
+import { tanstackRouterAdapter } from '@ottabase/brand-engine-react/routers';
+
+// Custom adapter — any object with a usePathname hook
+const myAdapter = { usePathname: () => useMyRouter().pathname };
+```
+
+## BrandPathSync
+
+For SSR/server-driven pathname sync (e.g. Next.js App Router where router hooks aren't available in Server
+Components), render `BrandPathSync` to push the current path into the brand context:
+
+```tsx
+import { BrandPathSync } from '@ottabase/brand-engine-react';
+
+// Render in your layout (client boundary):
+<BrandPathSync pathname={serverSidePathname} />
+```
+
+## Architecture
+
+```
+@ottabase/brand-engine        ← design tokens, CSS injection, API handlers (no React)
+@ottabase/brand-engine-react  ← BrandProvider, LayoutResolver, useBrand()
+@ottabase/ottalayout          ← LayoutConfig types, presets, route resolver, React slots
+```
+
+`BrandProvider` fetches one `GET /api/brand` and resolves the per-route config client-side using the route mappings
+in the response. See [`@ottabase/brand-engine`](../brand-engine/README.md) for server-side API handlers and token
+architecture.

--- a/packages/cf-realtime/README.md
+++ b/packages/cf-realtime/README.md
@@ -44,18 +44,26 @@ export default {
             return stub.fetch(request);
         }
 
-        // Broadcast endpoint — server-to-server only, requires a shared secret
+        // Broadcast endpoint — requires authentication + channel-level authorization
         if (url.pathname === '/api/broadcast' && request.method === 'POST') {
-            const token = request.headers.get('Authorization');
-            if (!token || token !== `Bearer ${env.BROADCAST_SECRET}`) {
+            const publisher = await validatePublisher(request, env);
+            if (!publisher) {
                 return new Response('Unauthorized', { status: 401 });
             }
 
-            const broadcaster = new RealtimeBroadcaster(env.OBCF_REALTIME);
             const body = await request.json<any>();
+            const channels = Array.isArray(body.channels) ? body.channels : [];
+            const allowedChannels = new Set(publisher.allowedChannels);
+
+            // Enforce per-channel publish permissions derived from the caller's session/API key
+            if (channels.some((channel) => !allowedChannels.has(channel))) {
+                return new Response('Forbidden', { status: 403 });
+            }
+
+            const broadcaster = new RealtimeBroadcaster(env.OBCF_REALTIME);
 
             const result = await broadcaster.broadcast({
-                channels: body.channels,
+                channels,
                 event: body.event,
                 data: body.data,
                 persistForOffline: body.persistForOffline ?? false,
@@ -67,6 +75,19 @@ export default {
         return new Response('Not Found', { status: 404 });
     },
 };
+
+type Publisher = { allowedChannels: string[] };
+
+// Validate an API key/session and return which channels the caller may publish to
+async function validatePublisher(request: Request, env: CloudflareEnv): Promise<Publisher | null> {
+    const token = request.headers.get('Authorization')?.replace('Bearer ', '');
+    if (!token) return null;
+
+    // Example: look up an API key that encodes allowed channels (KV/DB/custom auth)
+    // Return null to reject callers without publish permissions.
+    const apiKey = await env.API_KEYS?.get<Publisher>(token, 'json');
+    return apiKey ?? null;
+}
 ```
 
 ### 2. Wrangler Configuration
@@ -77,31 +98,33 @@ export default {
     "durable_objects": {
         "bindings": [{ "name": "OBCF_REALTIME", "class_name": "RealtimeActor" }]
     },
+    "kv_namespaces": [{ "binding": "API_KEYS", "id": "your-api-keys-kv" }],
     "migrations": [{ "tag": "v1", "new_classes": ["RealtimeActor"] }]
 }
 ```
 
-Set the broadcast secret as a Worker secret (never commit it):
+Provision a KV namespace for publisher API keys (each value should include `allowedChannels`):
 
 ```bash
-wrangler secret put BROADCAST_SECRET
+wrangler kv namespace create API_KEYS
+wrangler kv key put --binding=API_KEYS "server-1" '{"allowedChannels":["org-1201","system"]}'
 ```
 
-Then call the broadcast endpoint from your backend with the `Authorization` header:
+Then call the broadcast endpoint from your backend with the API key:
 
 ```typescript
 await fetch('https://your-worker.workers.dev/api/broadcast', {
     method: 'POST',
     headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.BROADCAST_SECRET}`,
+        Authorization: `Bearer ${process.env.REALTIME_PUBLISH_KEY}`,
     },
     body: JSON.stringify({ channels: ['org-1201'], event: 'update', data: {} }),
 });
 ```
 
-> **Never expose `/api/broadcast` without authentication.** Anyone who can reach the endpoint could inject
-> arbitrary events into any channel.
+> **Never expose `/api/broadcast` without authentication and channel-level authorization.** Anyone who can reach the
+> endpoint could inject arbitrary events into any channel unless you enforce publish scopes.
 
 ### 3. Client Usage (Browser/Node.js)
 

--- a/packages/cf-realtime/README.md
+++ b/packages/cf-realtime/README.md
@@ -44,8 +44,13 @@ export default {
             return stub.fetch(request);
         }
 
-        // Broadcast endpoint
+        // Broadcast endpoint — server-to-server only, requires a shared secret
         if (url.pathname === '/api/broadcast' && request.method === 'POST') {
+            const token = request.headers.get('Authorization');
+            if (!token || token !== `Bearer ${env.BROADCAST_SECRET}`) {
+                return new Response('Unauthorized', { status: 401 });
+            }
+
             const broadcaster = new RealtimeBroadcaster(env.OBCF_REALTIME);
             const body = await request.json<any>();
 
@@ -75,6 +80,28 @@ export default {
     "migrations": [{ "tag": "v1", "new_classes": ["RealtimeActor"] }]
 }
 ```
+
+Set the broadcast secret as a Worker secret (never commit it):
+
+```bash
+wrangler secret put BROADCAST_SECRET
+```
+
+Then call the broadcast endpoint from your backend with the `Authorization` header:
+
+```typescript
+await fetch('https://your-worker.workers.dev/api/broadcast', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.BROADCAST_SECRET}`,
+    },
+    body: JSON.stringify({ channels: ['org-1201'], event: 'update', data: {} }),
+});
+```
+
+> **Never expose `/api/broadcast` without authentication.** Anyone who can reach the endpoint could inject
+> arbitrary events into any channel.
 
 ### 3. Client Usage (Browser/Node.js)
 

--- a/packages/cf-realtime/README.md
+++ b/packages/cf-realtime/README.md
@@ -5,14 +5,14 @@ applications with WebSocket support, offline message queuing, and TypeScript-fir
 
 ## Features
 
-- 🚀 **Real-time WebSocket connections** with auto-reconnect
-- 📡 **Channel-based pub/sub** (subscribe to `org-1201`, `user-22`, `system`, etc.)
-- 💾 **Offline message queuing** - messages are delivered when clients come back online
-- 🔒 **TypeScript-first** with full type safety
-- ⚡ **Powered by Cloudflare Actors** - built on Durable Objects for global scale
-- 🎯 **Simple API** - Pusher-like interface for easy migration
-- 🔄 **Server-side broadcasting** to all online subscribers
-- 📊 **Built-in stats and monitoring**
+- **Real-time WebSocket connections** with auto-reconnect
+- **Channel-based pub/sub** (subscribe to `org-1201`, `user-22`, `system`, etc.)
+- **Offline message queuing** — messages are delivered when clients reconnect
+- **TypeScript-first** with full type safety
+- **Powered by Cloudflare Durable Objects** for global scale
+- **Pusher-like API** for easy migration
+- **Server-side broadcasting** to all online subscribers
+- **Built-in stats and monitoring**
 
 ## Installation
 
@@ -24,48 +24,39 @@ pnpm add @ottabase/cf-realtime
 
 ### 1. Server Setup (Cloudflare Worker)
 
-Create a Cloudflare Worker with the RealtimeActor:
+Export `RealtimeActor` from your worker entry point so Cloudflare registers the Durable Object class:
 
 ```typescript
-// worker.ts
-import { RealtimeActor, RealtimeBroadcaster } from '@ottabase/cf-realtime/server';
-import { handler } from '@cloudflare/actors';
+// cloudflare-worker.ts
+import { RealtimeBroadcaster } from '@ottabase/cf-realtime/server';
 
-export { RealtimeActor };
-export default handler(RealtimeActor);
+// Re-export the Durable Object class (required by Cloudflare)
+export { RealtimeActor } from '@ottabase/cf-realtime/server';
 
-// Environment bindings
-export interface Env {
-    REALTIME: DurableObjectNamespace;
-}
-
-// Example: Handle requests
 export default {
-    async fetch(request: Request, env: Env): Promise<Response> {
+    async fetch(request: Request, env: CloudflareEnv): Promise<Response> {
         const url = new URL(request.url);
 
-        // WebSocket upgrade - connect to the Actor
+        // WebSocket upgrade — forward to the Durable Object
         if (url.pathname === '/realtime' && request.headers.get('Upgrade') === 'websocket') {
             const id = env.OBCF_REALTIME.idFromName('global');
             const stub = env.OBCF_REALTIME.get(id);
             return stub.fetch(request);
         }
 
-        // REST API endpoint to broadcast messages
+        // Broadcast endpoint
         if (url.pathname === '/api/broadcast' && request.method === 'POST') {
             const broadcaster = new RealtimeBroadcaster(env.OBCF_REALTIME);
-            const body = await request.json();
+            const body = await request.json<any>();
 
             const result = await broadcaster.broadcast({
                 channels: body.channels,
                 event: body.event,
                 data: body.data,
-                persistForOffline: body.persistForOffline || false,
+                persistForOffline: body.persistForOffline ?? false,
             });
 
-            return new Response(JSON.stringify(result), {
-                headers: { 'Content-Type': 'application/json' },
-            });
+            return Response.json(result);
         }
 
         return new Response('Not Found', { status: 404 });
@@ -75,19 +66,14 @@ export default {
 
 ### 2. Wrangler Configuration
 
-```toml
-# wrangler.toml
-name = "cf-realtime-worker"
-main = "src/worker.ts"
-compatibility_date = "2024-01-01"
-
-[[durable_objects.bindings]]
-name = "OBCF_REALTIME"
-class_name = "RealtimeActor"
-
-[[migrations]]
-tag = "v1"
-new_classes = ["RealtimeActor"]
+```jsonc
+// wrangler.jsonc
+{
+    "durable_objects": {
+        "bindings": [{ "name": "OBCF_REALTIME", "class_name": "RealtimeActor" }]
+    },
+    "migrations": [{ "tag": "v1", "new_classes": ["RealtimeActor"] }]
+}
 ```
 
 ### 3. Client Usage (Browser/Node.js)
@@ -397,25 +383,6 @@ await broadcaster.send(`document:${docId}`, 'update', {
 });
 ```
 
-## Deployment
-
-1. **Install Wrangler CLI**:
-
-    ```bash
-    pnpm add -g wrangler
-    ```
-
-2. **Login to Cloudflare**:
-
-    ```bash
-    wrangler login
-    ```
-
-3. **Deploy**:
-    ```bash
-    wrangler deploy
-    ```
-
 ## Migration from Pusher
 
 cf-realtime provides a Pusher-like API, making migration straightforward:
@@ -435,25 +402,6 @@ cf-realtime provides a Pusher-like API, making migration straightforward:
 - **Auto-scaling**: Scales automatically with your traffic
 - **Low Latency**: Messages delivered in milliseconds
 
-## Pricing
-
-Based on Cloudflare Durable Objects pricing:
-
-- **Requests**: $0.15 per million requests
-- **Duration**: $12.50 per million GB-seconds
-- **WebSocket Messages**: Included in request pricing
-
-See [Cloudflare Pricing](https://developers.cloudflare.com/durable-objects/platform/pricing/) for details.
-
 ## License
 
 MIT
-
-## Contributing
-
-Contributions welcome! Please open an issue or PR.
-
-## Support
-
-- GitHub Issues: [Report a bug](https://github.com/thinkdj/ottabase/issues)
-- Documentation: [Cloudflare Actors](https://github.com/cloudflare/actors)

--- a/packages/cf-realtime/_GUIDE.md
+++ b/packages/cf-realtime/_GUIDE.md
@@ -51,19 +51,15 @@ Create `src/worker.ts`:
 
 ```typescript
 import { RealtimeActor, RealtimeBroadcaster } from '@ottabase/cf-realtime/server';
-import { handler } from '@cloudflare/actors';
 
-// Export Actor
+// Re-export the Durable Object class (required by Cloudflare)
 export { RealtimeActor };
 
-// Export default handler
-export default handler(RealtimeActor);
-
 export interface Env {
-    REALTIME: DurableObjectNamespace;
+    OBCF_REALTIME: DurableObjectNamespace;
+    BROADCAST_SECRET: string;
 }
 
-// Main worker
 export default {
     async fetch(request: Request, env: Env): Promise<Response> {
         const url = new URL(request.url);
@@ -75,8 +71,13 @@ export default {
             return stub.fetch(request);
         }
 
-        // Broadcast API
+        // Broadcast API — server-to-server only, requires a shared secret
         if (url.pathname === '/api/broadcast' && request.method === 'POST') {
+            const token = request.headers.get('Authorization');
+            if (!token || token !== `Bearer ${env.BROADCAST_SECRET}`) {
+                return new Response('Unauthorized', { status: 401 });
+            }
+
             const broadcaster = new RealtimeBroadcaster(env.OBCF_REALTIME);
             const body = await request.json();
 
@@ -113,6 +114,12 @@ class_name = "RealtimeActor"
 [[migrations]]
 tag = "v1"
 new_classes = ["RealtimeActor"]
+```
+
+Set the broadcast secret:
+
+```bash
+wrangler secret put BROADCAST_SECRET
 ```
 
 ## Step 5: Login and Deploy
@@ -159,9 +166,13 @@ In your backend API (Node.js, Next.js API routes, etc.):
 
 ```typescript
 // Send a broadcast to all subscribers
+// Use a shared BROADCAST_SECRET (set via `wrangler secret put BROADCAST_SECRET`)
 await fetch('https://my-realtime-worker.your-subdomain.workers.dev/api/broadcast', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.BROADCAST_SECRET}`,
+    },
     body: JSON.stringify({
         channels: ['org-1201'],
         event: 'notification',

--- a/packages/cf/README.md
+++ b/packages/cf/README.md
@@ -24,36 +24,9 @@ pnpm add @ottabase/cf
 
 ## Usage
 
-### Prisma D1 (Recommended)
-
-Use Prisma ORM with Cloudflare D1 for type-safe database access:
-
-```typescript
-import { createPrismaD1Client, getPrismaD1Client } from '@ottabase/cf/d1-prisma';
-
-export default {
-    async fetch(request: Request, env: Env) {
-        // Create a new client
-        const prisma = createPrismaD1Client(env.DB);
-
-        // Or use cached client (recommended for multiple queries)
-        const prisma = getPrismaD1Client(env.DB);
-
-        // Type-safe queries with Prisma
-        const users = await prisma.user.findMany({
-            where: { email: { contains: '@example.com' } },
-            include: { posts: true },
-        });
-
-        return Response.json(users);
-    },
-};
-```
-
-**Requirements:**
-
-- `@prisma/client` and `@prisma/adapter-d1` as peer dependencies
-- Generated Prisma client (run `pnpm db:generate`)
+> **Note:** For database access in Ottabase apps, use `@ottabase/db/drizzle-d1` with `@ottabase/ottaorm` (the standard
+> path). The raw D1 client and other helpers in this package are for direct Cloudflare binding access when OttaORM is not
+> being used.
 
 ### D1 Raw SQL
 

--- a/packages/referrals/README.md
+++ b/packages/referrals/README.md
@@ -1,66 +1,106 @@
 # @ottabase/referrals
 
-Referral system package for Ottabase. Provides schema, validation, and types for implementing a complete referral
-tracking system.
+Referral system package for Ottabase — schema, model, validation, and attribution tracking.
 
 ## Features
 
-- **Referral username**: Unique, user-chosen identifier for referral links
-- **First-touch attribution**: First valid referral code wins
-- **90-day expiry window**: Stored referral codes expire automatically
-- **Click analytics**: Referral clicks written to Cloudflare Analytics Engine (WAE)
-- **Conversion tracking**: D1 records created on signup (no per-click DB writes)
+- **Referral username** — Unique, user-chosen identifier for referral links (3–20 chars, `[a-zA-Z0-9_]`)
+- **First-touch attribution** — First valid referral code wins; stored for 90 days then expires
+- **Click analytics** — Referral clicks written to Cloudflare Analytics Engine (WAE); no per-click DB writes
+- **Conversion tracking** — D1 record created on signup, linked to the referring user
+
+## Install
+
+```bash
+pnpm add @ottabase/referrals
+```
 
 ## Usage
 
 ### Schema
 
+Export the table from your Drizzle schema file:
+
 ```typescript
-import { referralTrackingTable } from '@ottabase/referrals';
+// ottabase/db/schema.ts
+export { referralTrackingTable } from '@ottabase/referrals';
 ```
 
 ### Model
 
 ```typescript
 import { ReferralTracking } from '@ottabase/referrals';
+
+// Record a conversion (called at signup when referral cookie exists)
+await ReferralTracking.create({
+    userId: referrerId,
+    referralCode: 'alice',
+    referredUserId: newUser.id,
+    status: 'completed',
+    ipAddress: request.headers.get('cf-connecting-ip'),
+    userAgent: request.headers.get('user-agent'),
+    conversionAt: Date.now(),
+});
+
+// Query referrals for a user
+const referrals = await ReferralTracking.where({ userId: 'user-123' });
 ```
 
 ### Validation
 
 ```typescript
-import { validateReferralUsername } from '@ottabase/referrals';
+import { validateReferralUsername, isReferralExpired, REFERRAL_EXPIRY_MS } from '@ottabase/referrals';
 
 const result = validateReferralUsername('myusername');
 if (!result.valid) {
     console.error(result.error);
 }
+// Rules: 3–20 characters, letters/numbers/underscores only
+
+// Check if a stored referral timestamp has expired (90-day window)
+if (isReferralExpired(storedTimestamp)) {
+    // referral cookie is stale — ignore it
+}
+```
+
+**Validation constants:**
+
+```typescript
+import {
+    REFERRAL_USERNAME_MIN_LENGTH, // 3
+    REFERRAL_USERNAME_MAX_LENGTH, // 20
+    REFERRAL_USERNAME_PATTERN,   // /^[a-zA-Z0-9_]+$/
+    REFERRAL_EXPIRY_MS,          // 90 days in ms
+} from '@ottabase/referrals';
 ```
 
 ## Database Schema
 
-### ReferralTracking Table
+`referral_tracking` table — stores conversions only (clicks go to WAE):
 
-Stores conversions only (clicks go to WAE). Each row = one successful signup attributed to a referrer.
+| Column            | Type      | Description                              |
+| ----------------- | --------- | ---------------------------------------- |
+| `id`              | string    | Unique tracking ID                       |
+| `userId`          | string    | Referrer's user ID                       |
+| `referralCode`    | string    | Code used at click time                  |
+| `referredUserId`  | string    | Converted (new) user ID                  |
+| `status`          | string    | `completed` for conversion records       |
+| `ipAddress`       | string    | Client IP at signup                      |
+| `userAgent`       | string    | Browser user agent                       |
+| `referer`         | string    | HTTP Referer header                      |
+| `meta`            | JSON      | UTM params and full request context      |
+| `createdAt`       | timestamp | Record creation time                     |
+| `conversionAt`    | timestamp | Conversion time                          |
 
-- `id`: Unique tracking ID
-- `userId`: Referrer user ID
-- `referralCode`: Code used at click time
-- `referredUserId`: Converted user ID
-- `status`: completed (conversion records)
-- `ipAddress`: Client IP (captured at signup)
-- `userAgent`: Browser user agent
-- `referer`: HTTP Referer header
-- `meta`: JSON (UTM params, headers) — full context at conversion
-- `createdAt`: Record creation timestamp
-- `conversionAt`: Conversion timestamp
+## Integration Points
 
-## Integration
+1. **User model** — add `referralUsername` (the user's own code) and `referredById` fields
+2. **Signup flow** — read referral cookie, validate + attribute on account creation
+3. **Click tracking** — write to WAE on each referral link visit (via `@ottabase/analytics`)
+4. **Frontend** — display referral link (`/{username}`), show conversion stats
 
-This package should be integrated with:
+See the TanStack app implementation (`/api/referrals/*`) for a full example.
 
-1. User model (add `referralUsername` and `referredById` fields)
-2. Signup flow (attribute new users to referrers)
-3. Frontend (tracking component, dashboard)
-4. API routes (tracking, stats, username management)
+## License
 
-See the TanStack app implementation for a complete example.
+MIT

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -1,21 +1,136 @@
 # @ottabase/scripts
 
-Utility scripts for Ottabase monorepo, including Prisma schema management.
+CLI tools for Ottabase monorepo — Cloudflare resource setup, schema generation, migrations, and cache management.
 
-## Features
+## Overview
 
-### Modular Prisma Schema Management
+This package provides the `pnpm cf:*`, `pnpm db:*`, and `pnpm clean:*` scripts used across the monorepo.
 
-The `@ottabase/scripts` package provides a powerful system for managing Prisma schemas in a modular way. Instead of
-maintaining a single monolithic schema file, you can:
+## Cloudflare Setup CLI
 
-1. **Select specific core schemas** - Choose only the models you need (e.g., User, Post)
-2. **Configure database provider** - Easily switch between PostgreSQL, MySQL, SQLite, etc.
-3. **Combine with app-specific schemas** - Add your own models alongside core schemas
+### `pnpm cf:login`
+
+Verifies Wrangler authentication and logs in if needed.
+
+```bash
+pnpm cf:login
+```
+
+### `pnpm cf:setup`
+
+Interactive wizard that creates all required Cloudflare resources (D1, KV, R2, Queue) and prints the resource IDs for
+use as GitHub Secrets. Does **not** modify `wrangler.jsonc`.
+
+```bash
+pnpm cf:setup          # Interactive: select resources to create
+pnpm cf:setup --force  # Create all resources without prompts
+```
+
+**Output includes IDs for:**
+
+- `D1_DATABASE_ID` — Production D1 database
+- `D1_PREVIEW_DATABASE_ID` — Preview D1 database
+- `KV_NAMESPACE_ID` — Production KV namespace
+- `KV_PREVIEW_NAMESPACE_ID` — Preview KV namespace
+
+### `pnpm cf:validate`
+
+Validates that all resources in `wrangler.jsonc` exist in your Cloudflare account.
+
+```bash
+pnpm cf:validate
+```
+
+## DB Schema CLI
+
+The db CLI tools use `db.config.ts` in your app directory to manage Prisma schema concatenation and D1 migrations.
+
+### `pnpm db:generate`
+
+Concatenates modular Prisma schemas into a single `schema.prisma` and runs `prisma generate`.
+
+Create `db.config.ts` in your app:
+
+```typescript
+import { defineAppDbConfig } from '@ottabase/db';
+
+export default defineAppDbConfig({
+    appId: 'my-app',
+    features: ['auth'], // adds auth tables to schema
+});
+```
+
+Then run:
+
+```bash
+pnpm db:generate          # Concatenate schemas + prisma generate
+pnpm db:generate --verbose  # Verbose output
+pnpm db:generate --skip-generate  # Concatenate only, skip prisma generate
+```
+
+### `pnpm db:migrate`
+
+Generates SQL migrations from Prisma schema for Cloudflare D1.
+
+```bash
+pnpm db:migrate --name=add_users_table  # Generate migration
+pnpm db:migrate --name=add_column --apply  # Generate and apply to D1
+```
+
+### `pnpm db:migrate:apply`
+
+Applies pending D1 migrations.
+
+```bash
+pnpm db:migrate:apply          # Apply to local D1
+pnpm db:migrate:apply --remote  # Apply to remote/production D1
+```
+
+### `pnpm db:migrate:status`
+
+Shows which migrations have been applied.
+
+```bash
+pnpm db:migrate:status
+```
+
+## Cache/Reset CLI
+
+### `pnpm clean:cache`
+
+Clears Turborepo cache (`.turbo` directories and `node_modules/.cache/turbo`).
+
+```bash
+pnpm clean:cache
+```
+
+### `pnpm clean:reset`
+
+Full monorepo reset — removes `node_modules`, `dist`, and cache directories.
+
+```bash
+pnpm clean:reset
+```
+
+### `pnpm clean:db`
+
+Clears local Wrangler D1 state (`.wrangler/state/v3/d1/`).
+
+```bash
+pnpm clean:db
+```
+
+### `pnpm clean:kv`
+
+Clears local Wrangler KV state (`.wrangler/state/v3/kv/`).
+
+```bash
+pnpm clean:kv
+```
 
 ## Installation
 
-This package is already included in the Ottabase monorepo. For apps within the monorepo:
+This package is pre-installed in the monorepo. For apps within the monorepo:
 
 ```json
 {
@@ -24,244 +139,6 @@ This package is already included in the Ottabase monorepo. For apps within the m
     }
 }
 ```
-
-## Usage
-
-### 1. Create a Prisma Configuration File
-
-Create `ottabase/prisma/prisma.config.js` in your app:
-
-```javascript
-const { definePrismaConfig } = require('@ottabase/db/prisma');
-
-module.exports = definePrismaConfig({
-    // Select which core schemas to include
-    coreSchemas: ['user', 'post'],
-
-    // Configure database provider
-    provider: 'postgresql',
-
-    // Path to app-specific schema
-    appSchemaPath: 'ottabase/prisma/app.schema.prisma',
-
-    // Output path for generated schema
-    outputSchemaPath: 'prisma/schema.prisma',
-});
-```
-
-### 2. Add Script to package.json
-
-```json
-{
-    "scripts": {
-        "db:generate": "db-prisma-schema-concatenate"
-    }
-}
-```
-
-### 3. Run Schema Generation
-
-```bash
-pnpm db:generate
-```
-
-This will:
-
-1. Load your configuration
-2. Combine selected core schemas with your app schema
-3. Generate the final `prisma/schema.prisma`
-4. Run `prisma generate` to create the Prisma Client
-
-## Configuration Options
-
-### `coreSchemas` (string[])
-
-Array of core schema names to include from `@ottabase/db/prisma/schemas/`.
-
-**Available schemas:**
-
-- `"user"` - User authentication and management
-- `"post"` - Blog posts and content management
-- ...
-
-**Example:**
-
-```javascript
-coreSchemas: ['user', 'post'];
-```
-
-### `provider` (string)
-
-Database provider for the generated schema.
-
-**Options:**
-
-- `"postgresql"` (default)
-- `"mysql"`
-- `"sqlite"`
-- `"sqlserver"`
-- `"mongodb"`
-- `"cockroachdb"`
-
-**Example:**
-
-```javascript
-provider: 'mysql';
-```
-
-### `appSchemaPath` (string)
-
-Path to your app-specific schema file, relative to the app root.
-
-**Default:** `"ottabase/prisma/app.schema.prisma"`
-
-**Example:**
-
-```javascript
-appSchemaPath: 'ottabase/prisma/app.schema.prisma';
-```
-
-### `outputSchemaPath` (string)
-
-Path where the concatenated schema will be written, relative to the app root.
-
-**Default:** `"prisma/schema.prisma"`
-
-**Example:**
-
-```javascript
-outputSchemaPath: 'prisma/schema.prisma';
-```
-
-## Examples
-
-### Minimal Configuration (User only)
-
-```javascript
-const { definePrismaConfig } = require('@ottabase/db/prisma');
-
-module.exports = definePrismaConfig({
-    coreSchemas: ['user'],
-    provider: 'postgresql',
-});
-```
-
-### Full Configuration (All schemas, MySQL)
-
-```javascript
-const { definePrismaConfig } = require('@ottabase/db/prisma');
-
-module.exports = definePrismaConfig({
-    coreSchemas: ['user', 'post'],
-    provider: 'mysql',
-    appSchemaPath: 'ottabase/prisma/app.schema.prisma',
-    outputSchemaPath: 'prisma/schema.prisma',
-});
-```
-
-### SQLite for Development
-
-```javascript
-const { definePrismaConfig } = require('@ottabase/db/prisma');
-
-module.exports = definePrismaConfig({
-    coreSchemas: ['user'],
-    provider: 'sqlite',
-});
-```
-
-### No Core Schemas (App-only)
-
-```javascript
-module.exports = definePrismaConfig({
-    coreSchemas: [],
-    provider: 'postgresql',
-    appSchemaPath: 'ottabase/prisma/app.schema.prisma',
-});
-```
-
-## Generated Schema Structure
-
-The generated `schema.prisma` file will have the following structure:
-
-```prisma
-// This file is auto-generated by @ottabase/scripts
-// Do not edit this file directly
-
-// ---- Base Configuration ----
-generator client {
-  provider = "prisma-client-js"
-}
-
-datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
-}
-
-// ---- Core Schema: user ----
-model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  createdAt BigInt   // Set in app with Date.now()
-  updatedAt BigInt   // Set in app with Date.now()
-}
-
-// ---- Core Schema: post ----
-model Post {
-  id        String   @id @default(cuid())
-  title     String
-  content   String?  @db.Text
-  published Boolean  @default(false)
-  authorId  String?
-  createdAt BigInt   // Set in app with Date.now()
-  updatedAt BigInt   // Set in app with Date.now()
-}
-
-// ---- App Schema ----
-model MyAppModel {
-  id   String @id @default(cuid())
-  name String
-}
-```
-
-## Adding New Core Schemas
-
-To add new core schemas to `@ottabase/db`:
-
-1. Create a new file in `packages/db/prisma/schemas/` (e.g., `comment.schema.prisma`)
-2. Add only model definitions (no generator/datasource)
-3. Update the `CoreSchemaName` type in `@ottabase/db/src/prisma-config.ts`
-4. Update the README in `packages/db/prisma/schemas/README.md`
-
-## TypeScript Support
-
-For TypeScript configuration files, create `prisma.config.ts`:
-
-```typescript
-import { definePrismaConfig } from '@ottabase/db/prisma';
-
-export default definePrismaConfig({
-    coreSchemas: ['user', 'post'],
-    provider: 'postgresql',
-});
-```
-
-**Note:** The script will automatically look for both `.js` and `.ts` files. However, `.js` files are recommended for
-better compatibility with Node.js `require()`.
-
-## Troubleshooting
-
-### Schema not updating
-
-Make sure to run `pnpm db:generate` after changing your configuration.
-
-### TypeScript errors in config file
-
-Use a `.js` file instead of `.ts` for better compatibility, or ensure your TypeScript is properly configured.
-
-### Core schema not found
-
-Ensure the schema name in `coreSchemas` matches exactly with the available schemas in `@ottabase/db/prisma/schemas/`.
 
 ## License
 

--- a/packages/shortlinks/README.md
+++ b/packages/shortlinks/README.md
@@ -1,19 +1,18 @@
 # @ottabase/shortlinks
 
-A reusable shortlink management system designed for Cloudflare infrastructure.
+URL shortening system for Cloudflare D1 — redirect handling, interstitial pages, expiry, and click analytics.
 
 ## Features
 
-- 🔗 URL shortening with custom identifiers
-- 🎯 Multi-app database sharing via opt-in `appId` column
-- ⏰ Optional expiry dates
-- 💡 Helpers for expired/interstitial redirects (`renderExpiredShortlinkPage`, `renderShortlinkInterstitialPage`,
-  `buildRedirectResponse`)
-- 📊 Click tracking and analytics
-- 🏗️ Built on Drizzle ORM for Cloudflare D1
-- 🔄 Reusable across monorepo apps
+- URL shortening with custom short codes
+- Multi-app support via `appId`
+- Optional expiry dates
+- Interstitial countdown page before redirect
+- Expired link page
+- Click tracking via Cloudflare Analytics Engine (WAE)
+- Built on OttaORM for Cloudflare D1
 
-## Installation
+## Install
 
 ```bash
 pnpm add @ottabase/shortlinks
@@ -21,59 +20,103 @@ pnpm add @ottabase/shortlinks
 
 ## Usage
 
-### Import Model + Schema
+### Schema
+
+Export the table from your app's Drizzle schema:
 
 ```typescript
-import { Shortlink, shortlinksTable } from '@ottabase/shortlinks';
+// ottabase/db/schema.ts
+export { shortlinksTable } from '@ottabase/shortlinks';
 ```
 
-### Import Types
+### Model
 
 ```typescript
-import type { ShortlinkRecord, CreateShortlinkRequest } from '@ottabase/shortlinks';
+import { Shortlink } from '@ottabase/shortlinks';
+
+// Create a shortlink
+const link = await Shortlink.create({
+    fullUrl: 'https://github.com/ottabase',
+    shortCode: 'gh',
+    type: 'redirect',        // redirect | tracking | internal | external
+    interstitialEnabled: false,
+    interstitialSeconds: 5,  // countdown duration when interstitial enabled
+});
+
+// Find by short code
+const link = await Shortlink.findByCode('gh');
+const link = await Shortlink.findByCode('gh', { appId: 'myapp' });
+
+// List for an app
+const links = await Shortlink.forApp('myapp');
 ```
+
+### Redirect Handler
+
+Use `buildRedirectResponse` in your worker route handler for short code redirects:
+
+```typescript
+import { Shortlink, buildRedirectResponse, renderExpiredShortlinkPage, renderShortlinkInterstitialPage } from '@ottabase/shortlinks';
+
+// In your worker router:
+const shortlink = await Shortlink.findByCode(code);
+
+if (!shortlink) {
+    return new Response('Not found', { status: 404 });
+}
+
+// Handles expiry, interstitial, and direct redirect automatically
+return buildRedirectResponse(shortlink);
+```
+
+`buildRedirectResponse` checks `expiryDate` and `interstitialEnabled` internally. If you need custom pages:
+
+```typescript
+// Expired link page (reads theme from localStorage key 'ottabase.theme')
+return renderExpiredShortlinkPage();
+
+// Custom theme key
+return renderExpiredShortlinkPage({ themeStorageKey: 'myapp.theme' });
+
+// Interstitial countdown page
+return renderShortlinkInterstitialPage({
+    url: shortlink.fullUrl,
+    seconds: shortlink.interstitialSeconds ?? 5,
+    themeStorageKey: 'ottabase.theme',
+});
+```
+
+**Theme detection:** Both page helpers read `localStorage` for `'ottabase.theme'` (or your custom key) to apply
+light/dark mode. The value should be `'light'`, `'dark'`, or `'system'`.
 
 ## Database Schema
 
-The package exports a `shortlinksTable` Drizzle schema with the following fields:
+`shortlinks` table fields:
 
-- `id` - UUID primary key
-- `fullUrl` - Destination URL
-- `shortCode` - Unique short identifier
-- `type` - Link type (redirect, tracking, internal, external)
-- `appId` - Nullable app identifier (auto-set when `scopeByAppId: true` in config)
-- `interstitialEnabled` - Whether to show the interstitial countdown page
-- `interstitialSeconds` - Countdown duration (seconds) when interstitial is enabled
-- `expiryDate` - Optional expiry timestamp
-- `createdAt` - Creation timestamp
-- `updatedAt` - Last update timestamp
+| Column                | Description                                        |
+| --------------------- | -------------------------------------------------- |
+| `id`                  | UUID primary key                                   |
+| `fullUrl`             | Destination URL                                    |
+| `shortCode`           | Unique short identifier                            |
+| `type`                | `redirect`, `tracking`, `internal`, `external`     |
+| `appId`               | Nullable app identifier (multi-app support)        |
+| `interstitialEnabled` | Show countdown page before redirect                |
+| `interstitialSeconds` | Countdown duration (1–60)                          |
+| `expiryDate`          | Optional expiry Unix timestamp (ms)                |
+| `createdAt`           | Creation timestamp                                 |
+| `updatedAt`           | Last update timestamp                              |
 
-## Example
+## Click Analytics
 
-```typescript
-import { drizzle } from 'drizzle-orm/d1';
-import { shortlinksTable } from '@ottabase/shortlinks';
+Shortlink clicks are tracked via Cloudflare Analytics Engine. Configure the WAE binding in `wrangler.jsonc`:
 
-// Create a shortlink
-await db.insert(shortlinksTable).values({
-    fullUrl: 'https://github.com/ottabase',
-    shortCode: 'gh',
-    type: 'redirect',
-    appId: 'myapp',
-    interstitialEnabled: true,
-});
-
-// Query shortlinks
-const link = await db.select().from(shortlinksTable).where(eq(shortlinksTable.shortCode, 'gh')).get();
+```jsonc
+"analytics_engine_datasets": [
+    { "binding": "OBCF_ANALYTICS_SHORTLINKS", "dataset": "shortlink_clicks" }
+]
 ```
 
-For worker-side redirects, reuse the exported helpers instead of reconstructing the markup:
-
-```ts
-import { buildRedirectResponse } from '@ottabase/shortlinks';
-
-const response = buildRedirectResponse(shortlink);
-```
+Use `@ottabase/analytics` to write click events, then query via the `/analytics` page in the TanStack app.
 
 ## License
 

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -94,7 +94,8 @@ This component requires:
 
 - `@mantine/core` - For UI components and layout
 - `@ottabase/config` - For configuration management
-- `next/link` - For optional link functionality
+- `next/link` - For optional link functionality (**Next.js only**; if using TanStack Router or another framework,
+  wrap the Logo in your router's `<Link>` component instead and omit `linkUrl`)
 - Internal DarkModeToggle component (if darkModeSwitcher is true)
 
 ## Tree Shaking
@@ -116,8 +117,12 @@ import { DarkModeToggle } from '@ottabase/ui-components';
 
 ## Installation
 
-This package is part of the Ottabase monorepo and should be installed via the workspace dependencies.
-
 ```bash
-pnpm install @ottabase/ui-components
+pnpm add @ottabase/ui-components
+```
+
+For monorepo workspaces, use `workspace:*`:
+
+```json
+{ "dependencies": { "@ottabase/ui-components": "workspace:*" } }
 ```


### PR DESCRIPTION
## Summary

This PR significantly restructures documentation across the monorepo to clarify the CLI tooling landscape and improve guidance for Cloudflare resource setup. The changes consolidate scattered setup instructions into dedicated guides and update package READMEs to reflect current best practices.

## Key Changes

### Documentation Restructuring
- **`packages/scripts/README.md`**: Completely rewritten to document the three CLI tool families (`pnpm cf:*`, `pnpm db:*`, `pnpm clean:*`) with clear examples and usage patterns. Removed extensive Prisma schema configuration details in favor of concise `db.config.ts` guidance.
- **Root `README.md`**: Updated monorepo structure to reflect all current packages (40+ entries) with accurate descriptions. Added new packages like `analytics`, `notifications`, `brand-engine-react`, `ottalayout`, `ottablog`, `email`, `cron`, `config`, `ui-code-highlight`, `ui-split-pane`, `ottarenderer`, `ottaselect`, `cropper`, `spotlight`, `docs`, `forms`, and `i18n`.
- **`CLOUDFLARE_CONFIGURATION_GUIDE.md`**: Renumbered sections for clarity and updated Drizzle D1 usage examples to show direct `env` access pattern instead of `getCloudflareContext()`.
- **`CLOUDFLARE_DEPLOY.md`**: Updated deprecated `wrangler kv:namespace list` to `wrangler kv namespace list`.

### Package README Updates
- **`@ottabase/shortlinks`**: Expanded with complete usage examples, database schema table, and click tracking via WAE. Added theme detection details for interstitial/expired pages.
- **`@ottabase/cf-realtime`**: Simplified server setup instructions, updated Wrangler config to `jsonc` format, and removed redundant deployment section.
- **`@ottabase/brand-engine-react`**: Added comprehensive API documentation for `BrandProvider`, `useBrand()`, `LayoutResolver`, and `BrandPathSync`. Clarified architecture relationship with `@ottabase/brand-engine` and `@ottabase/ottalayout`.
- **`@ottabase/referrals`**: Restructured with clearer feature list, added validation constants reference, and expanded database schema documentation.
- **`@ottabase/cf`**: Added note directing users to `@ottabase/db/drizzle-d1` + `@ottabase/ottaorm` as the standard path for database access.
- **`@ottabase/ui-components`**: Clarified that `next/link` is Next.js-only and provided guidance for other frameworks.
- **`apps/ottabase-template-app-nextjs-homepage`**: Simplified and condensed README, removed emoji bullets, streamlined deployment instructions, and added link to TanStack template.
- **`apps/ottabase-template-app-tanstack`**: Updated Cloudflare setup to reference `pnpm cf:*` scripts and GitHub Secrets configuration.

### Notable Implementation Details
- CLI documentation now emphasizes the automated `pnpm cf:setup` script over manual resource creation.
- Consistent use of `OBCF_*` naming convention for Cloudflare bindings across all examples.
- Clarified multi-app support patterns in shortlinks and referrals packages.
- Updated all code examples to use modern patterns (e.g., `Response.json()`, `??` operator, `jsonc` format).