### PR TITLE
Add package toggles and move config to ottabase.config.ts

### DIFF
--- a/apps/ottabase-template-app-tanstack/cloudflare-worker.ts
+++ b/apps/ottabase-template-app-tanstack/cloudflare-worker.ts
@@ -6,6 +6,7 @@ import { handleBootstrapRoute, interceptIfNotReady, resolvePlatformState } from 
 import { injectBrandCriticalCSS } from './worker/lib/brand-html-inject';
 import { initDbConnection } from './worker/lib/db-utils';
 import { checkKillSwitches } from './worker/lib/killswitch';
+import { PACKAGES } from './worker/lib/worker-config';
 import { resolveApiRoute } from './worker/routes/router';
 import { handleShortlinkFallback } from './worker/routes/shortlinks';
 
@@ -113,9 +114,11 @@ export default {
                 return apiResponse;
             }
 
-            const shortlinkFallbackResponse = await handleShortlinkFallback({ request, env, url });
-            if (shortlinkFallbackResponse) {
-                return shortlinkFallbackResponse;
+            if (PACKAGES.shortlinks) {
+                const shortlinkFallbackResponse = await handleShortlinkFallback({ request, env, url });
+                if (shortlinkFallbackResponse) {
+                    return shortlinkFallbackResponse;
+                }
             }
 
             if (!env.OBCF_ASSETS) {

--- a/apps/ottabase-template-app-tanstack/ottabase/queue/handlers.ts
+++ b/apps/ottabase-template-app-tanstack/ottabase/queue/handlers.ts
@@ -22,9 +22,11 @@ import { createResendMailer } from '@ottabase/email/providers/resend';
 import { createSESMailer } from '@ottabase/email/providers/ses';
 import type { JobHandler } from '@ottabase/queue';
 import type { CloudflareEnv } from '../../cloudflare-env';
+import { EMAIL_FROM_DEFAULT, EMAIL_SES_REGION } from '../../worker/lib/worker-config';
 
 function getMailer(env: CloudflareEnv): { mailer: Mailer | null; from: string } {
-    const from = (env as any).EMAIL_FROM || 'noreply@example.com';
+    // Email "from" and SES region are now configured in ottabase.config.ts
+    const from = EMAIL_FROM_DEFAULT;
     if ((env as any).EMAIL_RESEND_API_KEY) {
         return { mailer: createResendMailer({ apiKey: (env as any).EMAIL_RESEND_API_KEY }), from };
     }
@@ -33,7 +35,7 @@ function getMailer(env: CloudflareEnv): { mailer: Mailer | null; from: string } 
             mailer: createSESMailer({
                 accessKeyId: (env as any).AWS_ACCESS_KEY_ID,
                 secretAccessKey: (env as any).AWS_SECRET_ACCESS_KEY,
-                region: (env as any).AWS_REGION || 'us-east-1',
+                region: EMAIL_SES_REGION,
             }),
             from,
         };

--- a/apps/ottabase-template-app-tanstack/src/ottabase/components/layout/BrandFooter.tsx
+++ b/apps/ottabase-template-app-tanstack/src/ottabase/components/layout/BrandFooter.tsx
@@ -1,10 +1,11 @@
 import { memo } from 'react';
+import { APP_NAME } from '@/ottabase/config/app.config';
 
 export const BrandFooter = memo(function BrandFooter({ containerClass }: { containerClass: string }) {
     return (
         <footer className="border-t mt-auto">
             <div className={`mx-auto px-4 py-6 text-center text-xs text-muted-foreground ${containerClass}`}>
-                Built with Ottabase
+                Built with {APP_NAME}
             </div>
         </footer>
     );

--- a/apps/ottabase-template-app-tanstack/src/ottabase/config/app.config.ts
+++ b/apps/ottabase-template-app-tanstack/src/ottabase/config/app.config.ts
@@ -77,6 +77,12 @@ export const SPOTLIGHT_CONFIG = appConfig.features.spotlight;
 // Referrals
 export const REFERRALS_CONFIG = appConfig.features.referrals;
 
+// Auth behaviour
+export const AUTH_BEHAVIOR_CONFIG = appConfig.features.authBehavior;
+
+// Email (non-secret)
+export const EMAIL_CONFIG = appConfig.email;
+
 // Theme / Colors
 export const THEME_COLOR_DEFAULT = appConfig.theme.colorDefault;
 export const THEME_COLORS = appConfig.theme.colors;

--- a/apps/ottabase-template-app-tanstack/src/ottabase/config/log.config.ts
+++ b/apps/ottabase-template-app-tanstack/src/ottabase/config/log.config.ts
@@ -1,5 +1,6 @@
 import type { LogConfig } from '@ottabase/logger';
 import { LogLevelEnum } from '@ottabase/logger';
+import { APP_ID } from './app.config';
 
 // Safe access for non-Vite environments (SSR, tests) where import.meta.env may be undefined
 const env = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
@@ -26,7 +27,7 @@ export const logConfig: LogConfig = {
 
     // Global context to include in all logs
     context: {
-        app: 'ottabase-template-app-tanstack',
+        app: APP_ID,
         version: env?.VITE_APP_VERSION ?? '0.0.0',
     },
 
@@ -135,7 +136,7 @@ export const logConfig: LogConfig = {
 export const devLogConfig: LogConfig = {
     level: LogLevelEnum.DEBUG,
     context: {
-        app: 'ottabase-template-app-tanstack',
+        app: APP_ID,
         environment: 'development',
     },
     server: {
@@ -157,7 +158,7 @@ export const devLogConfig: LogConfig = {
 export const prodLogConfig: LogConfig = {
     level: LogLevelEnum.INFO,
     context: {
-        app: 'ottabase-template-app-tanstack',
+        app: APP_ID,
         environment: 'production',
     },
     server: {

--- a/apps/ottabase-template-app-tanstack/src/ottabase/state/appState.ts
+++ b/apps/ottabase-template-app-tanstack/src/ottabase/state/appState.ts
@@ -2,7 +2,7 @@
  * App Global State
  * Central state management for ottabase-template-app-tanstack
  */
-import { APP_ID } from '@/ottabase/config/app.config';
+import { APP_ID, APP_NAME } from '@/ottabase/config/app.config';
 import { createAppState, type BaseUser, type SidebarState } from '@ottabase/state';
 import { createStore } from 'jotai';
 
@@ -15,7 +15,7 @@ export interface AppUser extends BaseUser {
 
 // Create app state with appName
 const { appStateAtom, atoms, createAtom } = createAppState<AppUser>({
-    appName: 'Ottabase',
+    appName: APP_NAME,
     initialState: {
         appId: APP_ID,
         organizationId: null,

--- a/apps/ottabase-template-app-tanstack/src/pages/docs/docs.config.ts
+++ b/apps/ottabase-template-app-tanstack/src/pages/docs/docs.config.ts
@@ -1,3 +1,4 @@
+import { APP_NAME } from '@/ottabase/config/app.config';
 import type { DocsConfig, DocsSource } from '@ottabase/docs';
 import { extractTitle, fileNameToSlug, slugToTitle } from '@ottabase/docs';
 
@@ -81,7 +82,7 @@ const packageModules = import.meta.glob('/../../packages/*/README.md', {
 }) as Record<string, () => Promise<string>>;
 
 export const docsConfig: DocsConfig = {
-    title: 'Ottabase Docs',
+    title: `${APP_NAME} Docs`,
     basePath: '/docs',
     theme: 'spacious',
     codeRenderMode: 'ui-code-highlight',

--- a/apps/ottabase-template-app-tanstack/worker/bootstrap/pages.ts
+++ b/apps/ottabase-template-app-tanstack/worker/bootstrap/pages.ts
@@ -293,7 +293,7 @@ export function renderWizardPage(state: PlatformStateResult): string {
       <h3 style="margin-top:0.75rem">Email (Optional)</h3>
       <table class="env-table">
         <tr><td>EMAIL_RESEND_API_KEY</td><td>API key from <a href="https://resend.com" target="_blank" style="color:var(--accent-light)">Resend</a> (recommended)</td></tr>
-        <tr><td>EMAIL_FROM</td><td>Sender address (default: noreply@example.com)</td></tr>
+        <tr><td colspan="2" style="font-size:0.85em;opacity:0.8">Sender address &amp; SES region are configured in <code>ottabase.config.ts</code> → <code>email</code></td></tr>
       </table>
       <h3 style="margin-top:0.75rem">Security (Recommended)</h3>
       <table class="env-table">

--- a/apps/ottabase-template-app-tanstack/worker/lib/worker-config.ts
+++ b/apps/ottabase-template-app-tanstack/worker/lib/worker-config.ts
@@ -66,3 +66,12 @@ export const AUTH_DISABLE_CREDENTIALS: boolean = cfg.features?.authBehavior?.dis
  * Default: false
  */
 export const AUTH_VERBOSE: boolean = cfg.features?.authBehavior?.verbose ?? false;
+
+// ── Package toggles ──────────────────────────────────────────
+/** Built-in package enabled/disabled flags from ottabase.config.ts */
+export const PACKAGES = {
+    ottablog: cfg.packages?.ottablog ?? false,
+    shortlinks: cfg.packages?.shortlinks ?? false,
+    referrals: cfg.packages?.referrals ?? false,
+    brandEngine: cfg.packages?.brandEngine ?? false,
+} as const;

--- a/apps/ottabase-template-app-tanstack/worker/routes/email.ts
+++ b/apps/ottabase-template-app-tanstack/worker/routes/email.ts
@@ -18,17 +18,17 @@ export function handleEmailProviders(context: EmailRouteContext): Response {
         resend: {
             available: !!env.EMAIL_RESEND_API_KEY,
             required: ['EMAIL_RESEND_API_KEY'],
-            optional: ['EMAIL_FROM'],
+            configNote: 'Sender address configured in ottabase.config.ts → email.from',
         },
         ses: {
             available: !!(env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY),
             required: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
-            optional: ['AWS_REGION', 'EMAIL_FROM'],
+            configNote: 'Sender address and SES region configured in ottabase.config.ts → email',
         },
         nodemailer: {
             available: !!env.EMAIL_SERVER,
             required: ['EMAIL_SERVER'],
-            optional: ['EMAIL_FROM'],
+            configNote: 'Sender address configured in ottabase.config.ts → email.from',
         },
     };
 

--- a/apps/ottabase-template-app-tanstack/worker/routes/email.ts
+++ b/apps/ottabase-template-app-tanstack/worker/routes/email.ts
@@ -18,16 +18,19 @@ export function handleEmailProviders(context: EmailRouteContext): Response {
         resend: {
             available: !!env.EMAIL_RESEND_API_KEY,
             required: ['EMAIL_RESEND_API_KEY'],
+            optional: ['EMAIL_FROM'],
             configNote: 'Sender address configured in ottabase.config.ts → email.from',
         },
         ses: {
             available: !!(env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY),
             required: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+            optional: ['AWS_REGION', 'EMAIL_FROM'],
             configNote: 'Sender address and SES region configured in ottabase.config.ts → email',
         },
         nodemailer: {
             available: !!env.EMAIL_SERVER,
             required: ['EMAIL_SERVER'],
+            optional: ['EMAIL_FROM'],
             configNote: 'Sender address configured in ottabase.config.ts → email.from',
         },
     };

--- a/apps/ottabase-template-app-tanstack/worker/routes/router.ts
+++ b/apps/ottabase-template-app-tanstack/worker/routes/router.ts
@@ -3,6 +3,7 @@ import { errorResponse } from '@ottabase/utils/http-errors';
 import { jsonResponse } from '@ottabase/utils/http-response';
 import type { CloudflareEnv } from '../../cloudflare-env';
 import { getKillSwitchStatus } from '../lib/killswitch';
+import { PACKAGES } from '../lib/worker-config';
 import { handleAdminCronCreate, handleAdminCronList, handleCronTask } from './admin-cron';
 import {
     handleAdminDbRowDelete,
@@ -110,6 +111,12 @@ export async function resolveApiRoute(context: ApiRouteContext): Promise<Respons
     return handleMethodAgnosticRoutes(context);
 }
 
+function packageDisabledResponse(packageName: string): Response {
+    return errorResponse(`Package "${packageName}" is disabled in ottabase.config.ts`, 404, {
+        code: 'PACKAGE_DISABLED',
+    });
+}
+
 const METHOD_HANDLERS: Record<string, MethodHandler> = {
     GET: handleGetRoutes,
     POST: handlePostRoutes,
@@ -123,6 +130,7 @@ async function handleGetRoutes(context: ApiRouteContext): Promise<Response | nul
 
     // Brand API (GET /api/brand, POST /api/brand/apply, GET/POST /api/brand/themes, etc.)
     if (route.startsWith('/api/brand')) {
+        if (!PACKAGES.brandEngine) return packageDisabledResponse('brandEngine');
         const res = await handleBrandApi(context);
         if (res) return res;
     }
@@ -161,44 +169,49 @@ async function handleGetRoutes(context: ApiRouteContext): Promise<Response | nul
         return handleAdminCronList(context);
     }
 
+    // ── Ottablog routes (guarded) ──
+    if (route.startsWith('/api/blog')) {
+        if (!PACKAGES.ottablog) return packageDisabledResponse('ottablog');
+    }
     if (route.startsWith('/api/blog/studio/') && route === '/api/blog/studio/state') {
         return handleBlogStudioState(context);
     }
-
     if (route === '/api/blog/posts') {
         return handleBlogPostsList(context);
     }
-
     const blogBySlugMatch = route.match(/^\/api\/blog\/posts\/by-slug\/([^/]+)$/);
     if (blogBySlugMatch) {
         const slug = decodeURIComponent(blogBySlugMatch[1]);
         return handleBlogPostBySlug(context, slug);
     }
 
+    // ── Shortlinks routes (guarded) ──
+    if (route.startsWith('/api/shortlinks') || route === '/shortlinks/go') {
+        if (!PACKAGES.shortlinks) return packageDisabledResponse('shortlinks');
+    }
     if (route === '/api/shortlinks') {
         return handleShortlinksList(context);
     }
-
     if (route === '/api/shortlinks/analytics') {
         return handleShortlinksAnalytics(context);
     }
-
     if (route === '/shortlinks/go') {
         return handleShortlinkExplicitGo(context);
     }
 
+    // ── Referrals routes (guarded) ──
+    if (route.startsWith('/api/referrals')) {
+        if (!PACKAGES.referrals) return packageDisabledResponse('referrals');
+    }
     if (route === '/api/referrals/stats') {
         return handleReferralStats(context);
     }
-
     if (route === '/api/referrals/user') {
         return handleReferralUser(context);
     }
-
     if (route === '/api/referrals/tracking') {
         return handleReferralTrackingList(context);
     }
-
     if (route === '/api/referrals/analytics') {
         return handleReferralsAnalytics(context);
     }
@@ -280,6 +293,7 @@ async function handlePostRoutes(context: ApiRouteContext): Promise<Response | nu
     const { route } = context;
 
     if (route.startsWith('/api/brand')) {
+        if (!PACKAGES.brandEngine) return packageDisabledResponse('brandEngine');
         const res = await handleBrandApi(context);
         if (res) return res;
     }
@@ -308,27 +322,32 @@ async function handlePostRoutes(context: ApiRouteContext): Promise<Response | nu
         return handleAdminPromoteOwner(context);
     }
 
+    // ── Ottablog routes (guarded) ──
+    if (route.startsWith('/api/blog')) {
+        if (!PACKAGES.ottablog) return packageDisabledResponse('ottablog');
+    }
     if (route === '/api/blog/studio/theme/activate') {
         return handleBlogStudioActivateTheme(context);
     }
-
     if (route === '/api/blog/studio/plugin/enable') {
         return handleBlogStudioPluginEnable(context);
     }
-
     if (route === '/api/blog/studio/plugin/config') {
         return handleBlogStudioPluginConfig(context);
     }
-
     if (route === '/api/blog/posts/unlock') {
         return handleBlogPostUnlock(context);
     }
 
+    // ── Shortlinks routes (guarded) ──
     if (route === '/api/shortlinks') {
+        if (!PACKAGES.shortlinks) return packageDisabledResponse('shortlinks');
         return handleShortlinksCreate(context);
     }
 
+    // ── Referrals routes (guarded) ──
     if (route === '/api/referrals/track') {
+        if (!PACKAGES.referrals) return packageDisabledResponse('referrals');
         return handleReferralTrack(context);
     }
 
@@ -397,6 +416,7 @@ async function handlePatchRoutes(context: ApiRouteContext): Promise<Response | n
 
     const shortlinkMatch = route.match(/^\/api\/shortlinks\/(.+)$/);
     if (shortlinkMatch) {
+        if (!PACKAGES.shortlinks) return packageDisabledResponse('shortlinks');
         return handleShortlinkById(context, shortlinkMatch[1], 'PATCH');
     }
 
@@ -417,12 +437,14 @@ async function handleDeleteRoutes(context: ApiRouteContext): Promise<Response | 
     const { route, url } = context;
 
     if (route.startsWith('/api/brand')) {
+        if (!PACKAGES.brandEngine) return packageDisabledResponse('brandEngine');
         const res = await handleBrandApi(context);
         if (res) return res;
     }
 
     const shortlinkMatch = route.match(/^\/api\/shortlinks\/(.+)$/);
     if (shortlinkMatch) {
+        if (!PACKAGES.shortlinks) return packageDisabledResponse('shortlinks');
         return handleShortlinkById(context, shortlinkMatch[1], 'DELETE');
     }
 
@@ -461,11 +483,13 @@ async function handlePutRoutes(context: ApiRouteContext): Promise<Response | nul
     const { route } = context;
 
     if (route.startsWith('/api/brand')) {
+        if (!PACKAGES.brandEngine) return packageDisabledResponse('brandEngine');
         const res = await handleBrandApi(context);
         if (res) return res;
     }
 
     if (route === '/api/referrals/username') {
+        if (!PACKAGES.referrals) return packageDisabledResponse('referrals');
         return handleReferralUsernameUpdate(context);
     }
 

--- a/apps/ottabase-template-app-tanstack/worker/routes/router.ts
+++ b/apps/ottabase-template-app-tanstack/worker/routes/router.ts
@@ -3,7 +3,7 @@ import { errorResponse } from '@ottabase/utils/http-errors';
 import { jsonResponse } from '@ottabase/utils/http-response';
 import type { CloudflareEnv } from '../../cloudflare-env';
 import { getKillSwitchStatus } from '../lib/killswitch';
-import { PACKAGES } from '../lib/worker-config';
+import { APP_ID, APP_NAME, PACKAGES } from '../lib/worker-config';
 import { handleAdminCronCreate, handleAdminCronList, handleCronTask } from './admin-cron';
 import {
     handleAdminDbRowDelete,
@@ -138,7 +138,7 @@ async function handleGetRoutes(context: ApiRouteContext): Promise<Response | nul
     if (route === '/api/health') {
         return jsonResponse({
             ok: true,
-            name: 'ottabase-template-app-tanstack',
+            name: APP_NAME,
             timestamp: Date.now(),
         });
     }
@@ -355,7 +355,7 @@ async function handlePostRoutes(context: ApiRouteContext): Promise<Response | nu
         return handleAnalyticsTrack({
             request: context.request,
             dataset: context.env.OBCF_ANALYTICS_CORE,
-            defaultAppId: 'ottabase-template',
+            defaultAppId: APP_ID,
         });
     }
 

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -118,4 +118,105 @@ describe('Configuration Utilities', () => {
             expect(appConfig.storage.prefix).toBe('verify');
         });
     });
-});
+
+    describe('createAppConfig – email defaults and env overrides', () => {
+        it('should use hardcoded defaults when no config or env vars are provided', () => {
+            const appConfig = createAppConfig({ appId: 'test', appName: 'Test' });
+            expect(appConfig.email.from).toBe('noreply@example.com');
+            expect(appConfig.email.sesRegion).toBe('us-east-1');
+        });
+
+        it('should use values from defaults when provided via userConfig', () => {
+            const userConfig = defineOttabaseConfig({
+                appId: 'email-app',
+                appName: 'Email App',
+                email: { from: 'hello@myapp.com', sesRegion: 'eu-west-1' },
+            });
+            const appConfig = createAppConfig(userConfigToOptions(userConfig));
+            expect(appConfig.email.from).toBe('hello@myapp.com');
+            expect(appConfig.email.sesRegion).toBe('eu-west-1');
+        });
+
+        it('should override email.from with EMAIL_FROM env var', () => {
+            process.env['EMAIL_FROM'] = 'override@env.com';
+            try {
+                const appConfig = createAppConfig({ appId: 'test', appName: 'Test' });
+                expect(appConfig.email.from).toBe('override@env.com');
+            } finally {
+                delete process.env['EMAIL_FROM'];
+            }
+        });
+
+        it('should override email.sesRegion with AWS_REGION env var', () => {
+            process.env['AWS_REGION'] = 'ap-southeast-1';
+            try {
+                const appConfig = createAppConfig({ appId: 'test', appName: 'Test' });
+                expect(appConfig.email.sesRegion).toBe('ap-southeast-1');
+            } finally {
+                delete process.env['AWS_REGION'];
+            }
+        });
+    });
+
+    describe('createAppConfig – authBehavior defaults and env overrides', () => {
+        it('should use hardcoded defaults when no config or env vars are provided', () => {
+            const appConfig = createAppConfig({ appId: 'test', appName: 'Test' });
+            expect(appConfig.features.authBehavior.sessionMaxAge).toBe(30 * 24 * 60 * 60);
+            expect(appConfig.features.authBehavior.requireEmailVerified).toBe(false);
+            expect(appConfig.features.authBehavior.disableCredentials).toBe(false);
+            expect(appConfig.features.authBehavior.verbose).toBe(false);
+        });
+
+        it('should use values from defaults when provided via userConfig', () => {
+            const userConfig = defineOttabaseConfig({
+                appId: 'auth-app',
+                appName: 'Auth App',
+                features: {
+                    authBehavior: {
+                        sessionMaxAge: 7 * 24 * 3600,
+                        requireEmailVerified: true,
+                        disableCredentials: true,
+                        verbose: true,
+                    },
+                },
+            });
+            const appConfig = createAppConfig(userConfigToOptions(userConfig));
+            expect(appConfig.features.authBehavior.sessionMaxAge).toBe(7 * 24 * 3600);
+            expect(appConfig.features.authBehavior.requireEmailVerified).toBe(true);
+            expect(appConfig.features.authBehavior.disableCredentials).toBe(true);
+            expect(appConfig.features.authBehavior.verbose).toBe(true);
+        });
+
+        it('should override sessionMaxAge with AUTH_SESSION_MAX_AGE env var', () => {
+            process.env['AUTH_SESSION_MAX_AGE'] = '3600';
+            try {
+                const appConfig = createAppConfig({ appId: 'test', appName: 'Test' });
+                expect(appConfig.features.authBehavior.sessionMaxAge).toBe(3600);
+            } finally {
+                delete process.env['AUTH_SESSION_MAX_AGE'];
+            }
+        });
+
+        it('should override requireEmailVerified with AUTH_REQUIRE_EMAIL_VERIFIED env var', () => {
+            process.env['AUTH_REQUIRE_EMAIL_VERIFIED'] = 'true';
+            try {
+                const appConfig = createAppConfig({ appId: 'test', appName: 'Test' });
+                expect(appConfig.features.authBehavior.requireEmailVerified).toBe(true);
+            } finally {
+                delete process.env['AUTH_REQUIRE_EMAIL_VERIFIED'];
+            }
+        });
+
+        it('should override disableCredentials and verbose with env vars', () => {
+            process.env['AUTH_DISABLE_CREDENTIALS'] = 'true';
+            process.env['AUTH_VERBOSE'] = 'true';
+            try {
+                const appConfig = createAppConfig({ appId: 'test', appName: 'Test' });
+                expect(appConfig.features.authBehavior.disableCredentials).toBe(true);
+                expect(appConfig.features.authBehavior.verbose).toBe(true);
+            } finally {
+                delete process.env['AUTH_DISABLE_CREDENTIALS'];
+                delete process.env['AUTH_VERBOSE'];
+            }
+        });
+    });

--- a/packages/config/src/createAppConfig.ts
+++ b/packages/config/src/createAppConfig.ts
@@ -1,4 +1,4 @@
-import { AppConfig, AppMeta, ConfigOptions, OttabaseUserConfig, SupportedUIFramework, ThemeColors } from './types';
+import { AppConfig, AppMeta, AuthBehaviorConfig, ConfigOptions, EmailConfig, OttabaseUserConfig, SupportedUIFramework, ThemeColors } from './types';
 
 /**
  * Creates app configuration by merging environment variables with defaults
@@ -156,6 +156,26 @@ export function createAppConfig(options: ConfigOptions = {}): AppConfig {
                 trackClicks: getBoolEnv('REFERRALS_TRACK_CLICKS', defaults.features?.referrals?.trackClicks ?? true),
                 expiryDays: getNumberEnv('REFERRALS_EXPIRY_DAYS', defaults.features?.referrals?.expiryDays ?? 30),
             },
+            authBehavior: {
+                sessionMaxAge: getNumberEnv(
+                    'AUTH_SESSION_MAX_AGE',
+                    defaults.features?.authBehavior?.sessionMaxAge ?? 30 * 24 * 60 * 60,
+                ),
+                requireEmailVerified: getBoolEnv(
+                    'AUTH_REQUIRE_EMAIL_VERIFIED',
+                    defaults.features?.authBehavior?.requireEmailVerified ?? false,
+                ),
+                disableCredentials: getBoolEnv(
+                    'AUTH_DISABLE_CREDENTIALS',
+                    defaults.features?.authBehavior?.disableCredentials ?? false,
+                ),
+                verbose: getBoolEnv('AUTH_VERBOSE', defaults.features?.authBehavior?.verbose ?? false),
+            },
+        },
+
+        email: {
+            from: getEnv('EMAIL_FROM', defaults.email?.from ?? 'noreply@example.com'),
+            sesRegion: getEnv('AWS_REGION', defaults.email?.sesRegion ?? 'us-east-1'),
         },
 
         model: {
@@ -260,8 +280,10 @@ export function userConfigToOptions(userConfig: OttabaseUserConfig): ConfigOptio
                       pagination: userConfig.features.pagination,
                       crudHub: userConfig.features.crudHub,
                       auth: userConfig.features.auth,
+                      authBehavior: userConfig.features.authBehavior,
                   }
                 : undefined,
+            email: userConfig.email,
         },
     };
 }

--- a/packages/config/src/createAppConfig.ts
+++ b/packages/config/src/createAppConfig.ts
@@ -1,4 +1,4 @@
-import { AppConfig, AppMeta, AuthBehaviorConfig, ConfigOptions, EmailConfig, OttabaseUserConfig, SupportedUIFramework, ThemeColors } from './types';
+import { AppConfig, AppMeta, ConfigOptions, OttabaseUserConfig, SupportedUIFramework, ThemeColors } from './types';
 
 /**
  * Creates app configuration by merging environment variables with defaults

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -102,6 +102,18 @@ export const DEFAULT_REFERRALS_CONFIG = {
     expiryDays: 30,
 } as const;
 
+export const DEFAULT_EMAIL_CONFIG = {
+    from: 'noreply@example.com',
+    sesRegion: 'us-east-1',
+} as const;
+
+export const DEFAULT_AUTH_BEHAVIOR_CONFIG = {
+    sessionMaxAge: 30 * 24 * 60 * 60, // 30 days
+    requireEmailVerified: false,
+    disableCredentials: false,
+    verbose: false,
+} as const;
+
 // Common storage keys
 export const STORAGE_KEYS = {
     THEME: 'theme',
@@ -167,4 +179,14 @@ export const ENV_KEYS = {
 
     // Storage
     STORAGE_PREFIX: 'STORAGE_PREFIX',
+
+    // Email (non-secret – from/region now in ottabase.config.ts, env var override kept)
+    EMAIL_FROM: 'EMAIL_FROM',
+    AWS_REGION: 'AWS_REGION',
+
+    // Auth behaviour (non-secret – now in ottabase.config.ts, env var override kept)
+    AUTH_SESSION_MAX_AGE: 'AUTH_SESSION_MAX_AGE',
+    AUTH_REQUIRE_EMAIL_VERIFIED: 'AUTH_REQUIRE_EMAIL_VERIFIED',
+    AUTH_DISABLE_CREDENTIALS: 'AUTH_DISABLE_CREDENTIALS',
+    AUTH_VERBOSE: 'AUTH_VERBOSE',
 } as const;

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -111,7 +111,12 @@ export interface AppConfig {
         auth: AuthConfig;
         pagination: PaginationConfig;
         referrals: ReferralsConfig;
+        /** Server-side auth behaviour (session length, verification gate, etc.) */
+        authBehavior: AuthBehaviorConfig;
     };
+
+    // Email Configuration (non-secret settings)
+    email: EmailConfig;
 
     // Model Configuration
     model: {
@@ -138,7 +143,11 @@ export interface ConfigOptions {
             auth?: Partial<AuthConfig>;
             pagination?: Partial<PaginationConfig>;
             referrals?: Partial<ReferralsConfig>;
+            /** Server-side auth behaviour flags */
+            authBehavior?: Partial<AuthBehaviorConfig>;
         };
+        /** Email/mailer settings (non-secret) */
+        email?: Partial<EmailConfig>;
         model?: Partial<AppConfig['model']>;
     };
     envPrefix?: string;


### PR DESCRIPTION
## Summary
This PR introduces package-level feature toggles and migrates email and auth behavior configuration from environment variables to `ottabase.config.ts`. It enables users to selectively enable/disable built-in packages (ottablog, shortlinks, referrals, brandEngine) and centralize non-secret configuration in the config file.

## Key Changes

### Package Toggles
- Added `PACKAGES` constant in `worker/lib/worker-config.ts` that reads from `cfg.packages` configuration
- Implemented package guards throughout the router (`worker/routes/router.ts`) that return a 404 with `PACKAGE_DISABLED` error code when a disabled package is accessed
- Protected routes for: ottablog, shortlinks, referrals, and brandEngine across GET, POST, PATCH, DELETE, and PUT handlers
- Added package check in `cloudflare-worker.ts` to conditionally enable shortlink fallback handling

### Configuration Migration
- **Email Configuration**: Moved `EMAIL_FROM` and `AWS_REGION` (SES) from environment variables to `ottabase.config.ts` under `email` section with defaults
- **Auth Behavior**: Moved `AUTH_SESSION_MAX_AGE`, `AUTH_REQUIRE_EMAIL_VERIFIED`, `AUTH_DISABLE_CREDENTIALS`, and `AUTH_VERBOSE` to `ottabase.config.ts` under `features.authBehavior`
- Updated `createAppConfig()` to read these values from config with environment variable overrides
- Added `DEFAULT_EMAIL_CONFIG` and `DEFAULT_AUTH_BEHAVIOR_CONFIG` constants
- Updated type definitions in `packages/config/src/types.ts` to include `EmailConfig` and `AuthBehaviorConfig`

### Code Consolidation
- Replaced hardcoded app name strings (`'ottabase-template-app-tanstack'`) with `APP_ID` and `APP_NAME` constants throughout:
  - Health check endpoint
  - Log configuration (dev and prod)
  - App state initialization
  - Footer component
  - Docs page title
  - Analytics tracking
- Updated email provider documentation to reference the new config location instead of environment variables

### Implementation Details
- Package guards are checked at route entry points before handler execution
- All disabled package responses use consistent error format with `PACKAGE_DISABLED` code
- Configuration maintains backward compatibility with environment variable overrides
- Email configuration is now centralized but still respects provider-specific env vars (API keys, credentials)

https://claude.ai/code/session_01VrsgTM282BW4TFws7ZfnkE