### PR TITLE
Steps plugin and renderer

### DIFF
--- a/apps/ottabase-template-app-tanstack/src/pages/demo/ottaeditor/EditorClient.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/demo/ottaeditor/EditorClient.tsx
@@ -42,6 +42,25 @@ const sampleDataFull: OutputData = {
                 text: 'This editor uses the <b>AdvancedImageTool</b> for image handling. Try dragging and dropping an image or pasting a URL!',
             },
         },
+        {
+            type: 'steps',
+            data: {
+                items: [
+                    {
+                        title: 'Plan the sequence',
+                        content: 'Use a short title and one or two lines of supporting context for each step.',
+                    },
+                    {
+                        title: 'Refine the details',
+                        content: 'Reorder or delete steps from the actions menu to keep the flow concise.',
+                    },
+                    {
+                        title: 'Save and render',
+                        content: 'The same block data renders as a vertical timeline in ottarenderer.',
+                    },
+                ],
+            },
+        },
         // We'll let the user add an image manually to test upload
     ],
     version: '2.30.7',

--- a/apps/ottabase-template-app-tanstack/src/pages/demo/renderer/RendererDemoPage.tsx
+++ b/apps/ottabase-template-app-tanstack/src/pages/demo/renderer/RendererDemoPage.tsx
@@ -106,6 +106,26 @@ const sampleEditorJSData = {
             },
         },
         {
+            id: 'steps1',
+            type: 'steps',
+            data: {
+                items: [
+                    {
+                        title: 'Choose the right block mix',
+                        content: 'Start with headers, paragraphs, and supporting media so the content structure is clear.',
+                    },
+                    {
+                        title: 'Layer in guided actions',
+                        content: 'Use steps when readers need a clear sequence instead of a dense paragraph wall.',
+                    },
+                    {
+                        title: 'Ship a polished walkthrough',
+                        content: 'Render the same saved block as a clean timeline in your frontend with minimal styling work.',
+                    },
+                ],
+            },
+        },
+        {
             id: 'quote1',
             type: 'quote',
             data: {
@@ -360,6 +380,7 @@ export function RendererDemoPage() {
                             <ul className="text-sm text-muted-foreground space-y-1">
                                 <li>• Advanced Image Block (with borders, backgrounds, aspect ratios)</li>
                                 <li>• Interactive Checklist</li>
+                                <li>• Steps timeline / walkthrough block</li>
                                 <li>• Code Block (with language labels)</li>
                                 <li>• List (ordered/unordered with nesting)</li>
                                 <li>• Quote (with alignment options)</li>

--- a/packages/ottaeditor/README.md
+++ b/packages/ottaeditor/README.md
@@ -4,7 +4,7 @@ A flexible EditorJS wrapper with typesafe plugin management for React applicatio
 
 ## Features
 
-- **21 pre-installed plugins** (15 Editor.js + 6 custom blocks)
+- **22 pre-installed plugins** (15 Editor.js + 7 custom blocks)
 - **Type-safe plugin selection** with autocomplete
 - **TypeScript support**
 - **Custom plugin integration**
@@ -34,6 +34,7 @@ Raw HTML blocks are sanitized on save to remove wrapper/executable tags (for exa
 - **Layout** – Multi-column layout with six preset splits; each column hosts a full nested editor
 - **Disclosure** – Transparency block with AI usage disclosure (slight/mid/high/custom %) and sponsored-content
   disclaimer (preset or custom wording)
+- **Steps** – Minimal step-by-step timeline editor with add, reorder, and delete controls
 
 CTA and Disclosure generate instance-scoped input IDs/names so multiple blocks can coexist without DOM ID or radio-group
 collisions.
@@ -90,7 +91,7 @@ Use these names with `defaultPlugins`:
 
 `'header'`, `'paragraph'`, `'list'`, `'checklist'`, `'code'`, `'quote'`, `'table'`, `'warning'`, `'delimiter'`,
 `'linkTool'`, `'embed'`, `'raw'`, `'Marker'`, `'underline'`, `'inlineCode'`, `'spoiler'`, `'cta'`, `'review'`, `'map'`,
-`'layout'`, `'disclosure'`
+`'layout'`, `'disclosure'`, `'steps'`
 
 ## API
 
@@ -171,6 +172,18 @@ interface DisclosureData {
 interface LayoutData {
     preset: '1-1' | '1-3' | '3-1' | '1-2' | '2-1' | '1-1-1';
     columns: Array<{ content: OutputData }>;
+}
+```
+
+### Steps
+
+```typescript
+// Saved data shape
+interface StepsData {
+    items: Array<{
+        title: string;
+        content: string;
+    }>;
 }
 ```
 

--- a/packages/ottaeditor/src/defaultPlugins.ts
+++ b/packages/ottaeditor/src/defaultPlugins.ts
@@ -21,6 +21,7 @@ import MapTool from './tools/MapTool/MapTool';
 import RawHtmlTool from './tools/RawHtmlTool/RawHtmlTool';
 import ReviewTool from './tools/ReviewTool/ReviewTool';
 import SpoilerTool from './tools/SpoilerTool/SpoilerTool';
+import StepsTool from './tools/StepsTool/StepsTool';
 import type { OttaEditorPlugin } from './types';
 
 const Raw = RawHtmlTool;
@@ -50,6 +51,7 @@ export const DEFAULT_PLUGIN_NAMES = {
     MAP: 'map',
     LAYOUT: 'layout',
     DISCLOSURE: 'disclosure',
+    STEPS: 'steps',
 } as const;
 
 /**
@@ -218,6 +220,11 @@ export const defaultPlugins: OttaEditorPlugin[] = [
         tool: DisclosureTool as any,
         config: {} as any,
     },
+    {
+        name: DEFAULT_PLUGIN_NAMES.STEPS,
+        tool: StepsTool as any,
+        config: {} as any,
+    },
 ];
 
 /**
@@ -265,6 +272,7 @@ export {
     Raw,
     ReviewTool,
     SpoilerTool,
+    StepsTool,
     Table,
     Underline,
     Warning,

--- a/packages/ottaeditor/src/index.ts
+++ b/packages/ottaeditor/src/index.ts
@@ -29,6 +29,7 @@ export {
     Raw,
     ReviewTool,
     SpoilerTool,
+    StepsTool,
     Table,
     Underline,
     Warning,
@@ -46,6 +47,7 @@ export type { LayoutColumnData, LayoutData, LayoutPreset, LayoutToolConfig } fro
 export type { MapData, MapProvider, MapTheme, MapToolConfig } from './tools/MapTool/MapTool';
 export { default as MediaLibraryTool } from './tools/MediaLibraryTool/MediaLibraryTool';
 export { default as RawHtmlTool } from './tools/RawHtmlTool/RawHtmlTool';
+export type { StepsData, StepsItem, StepsToolConfig } from './tools/StepsTool/StepsTool';
 
 export type { DefaultPluginName } from './defaultPlugins';
 

--- a/packages/ottaeditor/src/tools/StepsTool/StepsTool.css
+++ b/packages/ottaeditor/src/tools/StepsTool/StepsTool.css
@@ -1,0 +1,209 @@
+/* Minimal chrome for Steps */
+.ob-plugin.cdx-steps__wrapper,
+.cdx-steps__wrapper {
+    background: transparent;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+}
+
+.cdx-steps__toolbar,
+.cdx-steps__footer {
+    display: flex;
+    align-items: center;
+}
+
+.cdx-steps__footer {
+    padding-left: 48px;
+}
+
+.cdx-steps__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin: 12px 0 4px;
+}
+
+.cdx-steps__item {
+    display: grid;
+    grid-template-columns: 32px minmax(0, 1fr);
+    gap: 16px;
+    align-items: stretch;
+}
+
+.cdx-steps__rail {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.cdx-steps__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 9999px;
+    border: none;
+    background: hsl(var(--foreground));
+    color: hsl(var(--background));
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    box-shadow: 0 6px 14px rgb(15 23 42 / 0.28);
+}
+
+.cdx-steps__line {
+    width: 1px;
+    flex: 1;
+    margin: 8px 0;
+    background: hsl(var(--border));
+    min-height: 48px;
+}
+
+.cdx-steps__card {
+    position: relative;
+    padding: 2px 0 20px;
+}
+
+.cdx-steps__item-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.cdx-steps__title-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: hsl(var(--foreground));
+    font-size: 19px;
+    font-weight: 600;
+    line-height: 1.4;
+    padding: 2px 0;
+    min-width: 0;
+}
+
+.cdx-steps__title-input::placeholder,
+.cdx-steps__content-input::placeholder {
+    color: hsl(var(--muted-foreground));
+}
+
+.cdx-steps__content-input {
+    width: 100%;
+    margin-top: 6px;
+    padding: 0;
+    border: none;
+    outline: none;
+    resize: vertical;
+    min-height: 60px;
+    background: transparent;
+    color: hsl(var(--muted-foreground));
+    font-size: 15px;
+    line-height: 1.65;
+    box-shadow: none;
+}
+
+.cdx-steps__menu-wrap {
+    position: relative;
+    flex-shrink: 0;
+}
+
+.cdx-steps__icon-button,
+.cdx-steps__add-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    border-radius: 10px;
+    cursor: pointer;
+    transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        color 0.15s ease,
+        box-shadow 0.15s ease;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+}
+
+.cdx-steps__icon-button {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+}
+
+.cdx-steps__add-button {
+    height: 32px;
+    padding: 0 12px;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.cdx-steps__add-button--secondary {
+    width: 32px;
+    padding: 0;
+}
+
+.cdx-steps__add-button--secondary span {
+    display: none;
+}
+
+.cdx-steps__icon-button:hover,
+.cdx-steps__add-button:hover,
+.cdx-steps__menu-item:hover:not(:disabled) {
+    background: hsl(var(--muted));
+}
+
+.cdx-steps__icon-button:focus-visible,
+.cdx-steps__add-button:focus-visible,
+.cdx-steps__menu-item:focus-visible,
+.cdx-steps__title-input:focus-visible,
+.cdx-steps__content-input:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+}
+
+.cdx-steps__menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 136px;
+    padding: 6px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    background: hsl(var(--background));
+    box-shadow:
+        0 10px 15px -3px rgb(0 0 0 / 0.08),
+        0 4px 6px -4px rgb(0 0 0 / 0.08);
+}
+
+.cdx-steps__menu-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 10px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: hsl(var(--foreground));
+    cursor: pointer;
+    text-align: left;
+    font-size: 13px;
+}
+
+.cdx-steps__menu-item--danger {
+    color: hsl(var(--destructive));
+}
+
+.cdx-steps__menu-item:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}

--- a/packages/ottaeditor/src/tools/StepsTool/StepsTool.test.ts
+++ b/packages/ottaeditor/src/tools/StepsTool/StepsTool.test.ts
@@ -1,0 +1,84 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DEFAULT_PLUGIN_NAMES, defaultPluginsMap } from '../../defaultPlugins';
+import StepsTool, { type StepsData } from './StepsTool';
+
+const createdTools: StepsTool[] = [];
+
+function createTool(data?: Partial<StepsData>) {
+	const tool = new StepsTool({
+		api: {} as any,
+		data,
+		config: {},
+		block: { id: 'steps-test' },
+	});
+
+	const wrapper = tool.render();
+	document.body.appendChild(wrapper);
+	createdTools.push(tool);
+
+	return { tool, wrapper };
+}
+
+afterEach(() => {
+	createdTools.splice(0).forEach((tool) => tool.destroy?.());
+	document.body.innerHTML = '';
+});
+
+describe('StepsTool', () => {
+	it('registers the tool in the default plugin map', () => {
+		expect(DEFAULT_PLUGIN_NAMES.STEPS).toBe('steps');
+		expect(defaultPluginsMap.get(DEFAULT_PLUGIN_NAMES.STEPS)?.tool).toBe(StepsTool as any);
+	});
+
+	it('renders a minimal steps editor and saves filled items', () => {
+		const { tool } = createTool();
+
+		expect(screen.getAllByRole('button', { name: /add step/i })).toHaveLength(2);
+		expect(screen.getByLabelText('Step 1 title')).toBeTruthy();
+
+		fireEvent.input(screen.getByLabelText('Step 1 title'), {
+			target: { value: 'Choose your blocks' },
+		});
+		fireEvent.input(screen.getByLabelText('Step 1 content'), {
+			target: { value: 'Start with the content structure you want to publish.' },
+		});
+
+		expect(tool.save()).toEqual({
+			items: [
+				{
+					title: 'Choose your blocks',
+					content: 'Start with the content structure you want to publish.',
+				},
+			],
+		});
+	});
+
+	it('supports adding and reordering steps through the action menu', () => {
+		const { tool } = createTool({
+			items: [
+				{ title: 'First', content: 'Draft the outline.' },
+				{ title: 'Second', content: 'Review and refine.' },
+			],
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /open actions for step 1/i }));
+		fireEvent.click(screen.getByRole('menuitem', { name: /move down/i }));
+
+		expect(tool.save().items.map((item) => item.title)).toEqual(['Second', 'First']);
+
+		fireEvent.click(screen.getAllByRole('button', { name: /add step/i })[0]);
+		fireEvent.input(screen.getByLabelText('Step 3 title'), {
+			target: { value: 'Publish' },
+		});
+
+		expect(tool.save().items.map((item) => item.title)).toEqual(['Second', 'First', 'Publish']);
+	});
+
+	it('rejects empty payloads during validation', () => {
+		const { tool } = createTool();
+
+		expect(tool.validate({ items: [] })).toBe(false);
+		expect(tool.validate({ items: [{ title: 'Ready', content: '' }] })).toBe(true);
+	});
+});

--- a/packages/ottaeditor/src/tools/StepsTool/StepsTool.ts
+++ b/packages/ottaeditor/src/tools/StepsTool/StepsTool.ts
@@ -1,0 +1,365 @@
+import type { API, BlockTool } from '@editorjs/editorjs';
+import './StepsTool.css';
+
+export interface StepsItem {
+	title: string;
+	content: string;
+}
+
+export interface StepsData {
+	items: StepsItem[];
+}
+
+export interface StepsToolConfig {
+	titlePlaceholder?: string;
+	contentPlaceholder?: string;
+	defaultItems?: StepsItem[];
+}
+
+const PLUS_ICON =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>';
+
+const MENU_ICON =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.75"/><circle cx="12" cy="12" r="1.75"/><circle cx="12" cy="19" r="1.75"/></svg>';
+
+const MOVE_UP_ICON =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="m6 11 6-6 6 6"/></svg>';
+
+const MOVE_DOWN_ICON =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="m18 13-6 6-6-6"/></svg>';
+
+const DELETE_ICON =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M6 7l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12"/><path d="M9 7V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3"/></svg>';
+
+const STEPS_TOOLBOX_ICON =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2"/><circle cx="6" cy="12" r="2"/><circle cx="6" cy="18" r="2"/><path d="M10 6h8"/><path d="M10 12h8"/><path d="M10 18h8"/></svg>';
+
+export default class StepsTool implements BlockTool {
+	private data: StepsData;
+	private config: StepsToolConfig;
+	private wrapper: HTMLElement | null = null;
+	private listEl: HTMLElement | null = null;
+	private openMenuIndex: number | null = null;
+	private handleDocumentClickBound: (event: MouseEvent) => void;
+
+	static get CSS() {
+		return {
+			baseClass: 'cdx-steps',
+			wrapper: 'cdx-steps__wrapper',
+			toolbar: 'cdx-steps__toolbar',
+			addButton: 'cdx-steps__add-button',
+			addButtonSecondary: 'cdx-steps__add-button--secondary',
+			list: 'cdx-steps__list',
+			item: 'cdx-steps__item',
+			rail: 'cdx-steps__rail',
+			badge: 'cdx-steps__badge',
+			line: 'cdx-steps__line',
+			card: 'cdx-steps__card',
+			itemHeader: 'cdx-steps__item-header',
+			titleInput: 'cdx-steps__title-input',
+			contentInput: 'cdx-steps__content-input',
+			menuWrap: 'cdx-steps__menu-wrap',
+			iconButton: 'cdx-steps__icon-button',
+			menu: 'cdx-steps__menu',
+			menuItem: 'cdx-steps__menu-item',
+			menuItemDanger: 'cdx-steps__menu-item--danger',
+			footer: 'cdx-steps__footer',
+		};
+	}
+
+	static get toolbox() {
+		return {
+			title: 'Steps',
+			icon: STEPS_TOOLBOX_ICON,
+		};
+	}
+
+	static get enableLineBreaks() {
+		return true;
+	}
+
+	constructor({
+		data,
+		config,
+	}: {
+		data?: Partial<StepsData>;
+		config?: StepsToolConfig;
+		api: API;
+		block?: { id?: string };
+	}) {
+		this.config = config || {};
+		this.handleDocumentClickBound = this.handleDocumentClick.bind(this);
+
+		const initialItems = this.toEditableItems(data?.items);
+		this.data = {
+			items: initialItems.length ? initialItems : this.getDefaultItems(),
+		};
+	}
+
+	private getDefaultItems(): StepsItem[] {
+		const configuredItems = this.toEditableItems(this.config.defaultItems);
+		return configuredItems.length ? configuredItems : [{ title: '', content: '' }];
+	}
+
+	private toEditableItems(items?: Array<Partial<StepsItem>>): StepsItem[] {
+		return (items || []).map((item) => ({
+			title: String(item?.title ?? ''),
+			content: String(item?.content ?? ''),
+		}));
+	}
+
+	private toSavedItems(): StepsItem[] {
+		return this.data.items
+			.map((item) => ({
+				title: item.title.trim(),
+				content: item.content.trim(),
+			}))
+			.filter((item) => item.title !== '' || item.content !== '');
+	}
+
+	render(): HTMLElement {
+		document.removeEventListener('click', this.handleDocumentClickBound);
+
+		const wrapper = document.createElement('div');
+		wrapper.classList.add(StepsTool.CSS.baseClass, StepsTool.CSS.wrapper, 'ob-plugin');
+
+		const toolbar = document.createElement('div');
+		toolbar.classList.add(StepsTool.CSS.toolbar);
+		toolbar.appendChild(this.createAddButton('Add step', false));
+
+		const list = document.createElement('div');
+		list.classList.add(StepsTool.CSS.list);
+
+		const footer = document.createElement('div');
+		footer.classList.add(StepsTool.CSS.footer);
+		footer.appendChild(this.createAddButton('Add step', true));
+
+		wrapper.appendChild(toolbar);
+		wrapper.appendChild(list);
+		wrapper.appendChild(footer);
+
+		this.wrapper = wrapper;
+		this.listEl = list;
+
+		this.renderItems();
+		document.addEventListener('click', this.handleDocumentClickBound);
+
+		return wrapper;
+	}
+
+	private createAddButton(label: string, secondary: boolean): HTMLButtonElement {
+		const button = document.createElement('button');
+		button.type = 'button';
+		button.classList.add(StepsTool.CSS.addButton);
+		if (secondary) {
+			button.classList.add(StepsTool.CSS.addButtonSecondary);
+		}
+		button.innerHTML = `${PLUS_ICON}<span>${label}</span>`;
+		button.setAttribute('aria-label', label);
+		button.addEventListener('click', (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			this.addStep();
+		});
+		return button;
+	}
+
+	private renderItems(): void {
+		if (!this.listEl) {
+			return;
+		}
+
+		this.listEl.innerHTML = '';
+
+		this.data.items.forEach((item, index) => {
+			this.listEl?.appendChild(this.buildItem(index, item));
+		});
+	}
+
+	private buildItem(index: number, item: StepsItem): HTMLElement {
+		const itemEl = document.createElement('div');
+		itemEl.classList.add(StepsTool.CSS.item);
+
+		const rail = document.createElement('div');
+		rail.classList.add(StepsTool.CSS.rail);
+
+		const badge = document.createElement('div');
+		badge.classList.add(StepsTool.CSS.badge);
+		badge.textContent = String(index + 1);
+		rail.appendChild(badge);
+
+		if (index < this.data.items.length - 1) {
+			const line = document.createElement('div');
+			line.classList.add(StepsTool.CSS.line);
+			rail.appendChild(line);
+		}
+
+		const card = document.createElement('div');
+		card.classList.add(StepsTool.CSS.card);
+
+		const header = document.createElement('div');
+		header.classList.add(StepsTool.CSS.itemHeader);
+
+		const titleInput = document.createElement('input');
+		titleInput.type = 'text';
+		titleInput.classList.add(StepsTool.CSS.titleInput);
+		titleInput.placeholder = this.config.titlePlaceholder || 'Step title';
+		titleInput.value = item.title;
+		titleInput.setAttribute('aria-label', `Step ${index + 1} title`);
+		titleInput.setAttribute('data-step-title-index', String(index));
+		titleInput.addEventListener('input', (event) => {
+			this.data.items[index].title = (event.target as HTMLInputElement).value;
+		});
+
+		const menuWrap = document.createElement('div');
+		menuWrap.classList.add(StepsTool.CSS.menuWrap);
+
+		const menuButton = document.createElement('button');
+		menuButton.type = 'button';
+		menuButton.classList.add(StepsTool.CSS.iconButton);
+		menuButton.innerHTML = MENU_ICON;
+		menuButton.setAttribute('aria-label', `Open actions for step ${index + 1}`);
+		menuButton.setAttribute('aria-expanded', String(this.openMenuIndex === index));
+		menuButton.addEventListener('click', (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			this.openMenuIndex = this.openMenuIndex === index ? null : index;
+			this.renderItems();
+		});
+		menuWrap.appendChild(menuButton);
+
+		if (this.openMenuIndex === index) {
+			menuWrap.appendChild(this.buildMenu(index));
+		}
+
+		header.appendChild(titleInput);
+		header.appendChild(menuWrap);
+
+		const contentInput = document.createElement('textarea');
+		contentInput.classList.add(StepsTool.CSS.contentInput, 'ob-textarea');
+		contentInput.placeholder = this.config.contentPlaceholder || 'Describe this step...';
+		contentInput.rows = 3;
+		contentInput.value = item.content;
+		contentInput.setAttribute('aria-label', `Step ${index + 1} content`);
+		contentInput.setAttribute('data-step-content-index', String(index));
+		contentInput.addEventListener('input', (event) => {
+			this.data.items[index].content = (event.target as HTMLTextAreaElement).value;
+		});
+
+		card.appendChild(header);
+		card.appendChild(contentInput);
+
+		itemEl.appendChild(rail);
+		itemEl.appendChild(card);
+
+		return itemEl;
+	}
+
+	private buildMenu(index: number): HTMLElement {
+		const menu = document.createElement('div');
+		menu.classList.add(StepsTool.CSS.menu);
+		menu.setAttribute('role', 'menu');
+
+		menu.appendChild(
+			this.createMenuItem('Move up', MOVE_UP_ICON, index === 0, () => {
+				this.moveStep(index, -1);
+			}),
+		);
+		menu.appendChild(
+			this.createMenuItem('Move down', MOVE_DOWN_ICON, index === this.data.items.length - 1, () => {
+				this.moveStep(index, 1);
+			}),
+		);
+		menu.appendChild(
+			this.createMenuItem(
+				'Delete step',
+				DELETE_ICON,
+				false,
+				() => {
+					this.removeStep(index);
+				},
+				true,
+			),
+		);
+
+		return menu;
+	}
+
+	private createMenuItem(
+		label: string,
+		icon: string,
+		disabled: boolean,
+		onClick: () => void,
+		isDanger = false,
+	): HTMLButtonElement {
+		const button = document.createElement('button');
+		button.type = 'button';
+		button.classList.add(StepsTool.CSS.menuItem);
+		if (isDanger) {
+			button.classList.add(StepsTool.CSS.menuItemDanger);
+		}
+		button.innerHTML = `${icon}<span>${label}</span>`;
+		button.disabled = disabled;
+		button.setAttribute('role', 'menuitem');
+		button.addEventListener('click', (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if (button.disabled) {
+				return;
+			}
+			onClick();
+		});
+		return button;
+	}
+
+	private addStep(): void {
+		this.data.items.push({ title: '', content: '' });
+		this.openMenuIndex = null;
+		this.renderItems();
+	}
+
+	private moveStep(index: number, direction: -1 | 1): void {
+		const nextIndex = index + direction;
+		if (nextIndex < 0 || nextIndex >= this.data.items.length) {
+			return;
+		}
+
+		const [movedItem] = this.data.items.splice(index, 1);
+		this.data.items.splice(nextIndex, 0, movedItem);
+		this.openMenuIndex = null;
+		this.renderItems();
+	}
+
+	private removeStep(index: number): void {
+		if (this.data.items.length === 1) {
+			this.data.items = [{ title: '', content: '' }];
+		} else {
+			this.data.items.splice(index, 1);
+		}
+		this.openMenuIndex = null;
+		this.renderItems();
+	}
+
+	private handleDocumentClick(event: MouseEvent): void {
+		if (!this.wrapper || !this.wrapper.contains(event.target as Node)) {
+			if (this.openMenuIndex !== null) {
+				this.openMenuIndex = null;
+				this.renderItems();
+			}
+		}
+	}
+
+	save(): StepsData {
+		return {
+			items: this.toSavedItems(),
+		};
+	}
+
+	validate(savedData: StepsData): boolean {
+		return Array.isArray(savedData.items) && savedData.items.some((item) => item.title.trim() || item.content.trim());
+	}
+
+	destroy(): void {
+		document.removeEventListener('click', this.handleDocumentClickBound);
+	}
+}

--- a/packages/ottarenderer/README.md
+++ b/packages/ottarenderer/README.md
@@ -6,7 +6,7 @@ React renderer for [Editor.js](https://editorjs.io/) content and generic HTML.
 
 - **Editor.js Support**: Renders blocks from Editor.js (headers, paragraphs, lists, images, etc.).
 - **Custom Blocks**: Includes renderers for `@ottabase/ottaeditor` custom blocks (AdvancedImage, CTA, Disclosure,
-  Layout, Review, Spoiler, etc.).
+  Layout, Review, Spoiler, Steps, etc.).
 - **HTML Renderer**: Safe HTML rendering utility.
 - **Tailwind Configured**: Styled with Tailwind CSS via `@ottabase/ui-base`.
 - **Global Theming**: Components use semantic theme token classes (`bg-primary`, `text-foreground`, `border-border`) and
@@ -79,6 +79,7 @@ Header, Paragraph, List, Quote, Code, Table, Delimiter, Attaches.
 | `Quote`              | Styled pull-quote with attribution                                                   |
 | `Review`             | Product/service review card with star rating, pros/cons, CTA link, and verdict       |
 | `Spoiler`            | Click-to-reveal blurred text                                                         |
+| `Steps`              | Minimal numbered timeline for tutorials, onboarding, and walkthroughs                |
 | `Table`              | Data table                                                                           |
 | `Warning`            | Alert/callout box                                                                    |
 
@@ -133,6 +134,24 @@ import { CTA } from '@ottabase/ottarenderer';
         style: 'primary', // 'primary' | 'secondary' | 'outline' | 'ghost'
         alignment: 'center', // 'left' | 'center' | 'right'
         openInNewTab: false,
+    }}
+/>;
+```
+
+## Steps Block
+
+The `Steps` component renders a compact vertical timeline with numbered markers and theme-safe light/dark styling.
+
+```tsx
+import { Steps } from '@ottabase/ottarenderer';
+
+<Steps
+    data={{
+        items: [
+            { title: 'Choose a template', content: 'Pick the layout that fits your guide.' },
+            { title: 'Add the details', content: 'Write short, scannable content for each step.' },
+            { title: 'Publish', content: 'Render the saved steps data in your frontend.' },
+        ],
     }}
 />;
 ```

--- a/packages/ottarenderer/src/baseRenderers.ts
+++ b/packages/ottarenderer/src/baseRenderers.ts
@@ -13,6 +13,7 @@ import Map from './components/Map';
 import Quote from './components/Quote';
 import Review from './components/Review';
 import Spoiler from './components/Spoiler';
+import Steps from './components/Steps';
 import Table from './components/Table';
 import Warning from './components/Warning';
 
@@ -30,4 +31,5 @@ export const baseRenderers = {
     disclosure: Disclosure,
     review: Review,
     map: Map,
+    steps: Steps,
 };

--- a/packages/ottarenderer/src/components/Steps.test.tsx
+++ b/packages/ottarenderer/src/components/Steps.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { customRenderers } from '../EditorJsRenderer';
+import Steps from './Steps';
+
+describe('Steps renderer', () => {
+	it('renders numbered steps with titles and content', () => {
+		const { container } = render(
+			<Steps
+				data={{
+					items: [
+						{ title: 'Create the outline', content: 'Start with the structure of the guide.' },
+						{ title: 'Add supporting details', content: 'Fill each step with the key information.' },
+					],
+				}}
+			/>,
+		);
+
+		expect(screen.getByLabelText('Step list')).toBeTruthy();
+		expect(screen.getByText('Create the outline')).toBeTruthy();
+		expect(screen.getByText('Add supporting details')).toBeTruthy();
+		expect(container.querySelector('[data-step-index="1"]')).toBeTruthy();
+		expect(container.querySelector('[data-step-index="2"]')).toBeTruthy();
+	});
+
+	it('skips empty steps and returns null for empty payloads', () => {
+		const { container, rerender } = render(
+			<Steps
+				data={{
+					items: [
+						{ title: '', content: '' },
+						{ title: 'Only valid step', content: '' },
+					],
+				}}
+			/>,
+		);
+
+		expect(screen.getByText('Only valid step')).toBeTruthy();
+		expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(1);
+
+		rerender(<Steps data={{ items: [{ title: '', content: '' }] }} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('is registered in the renderer map', () => {
+		expect(customRenderers.steps).toBe(Steps);
+	});
+});

--- a/packages/ottarenderer/src/components/Steps.tsx
+++ b/packages/ottarenderer/src/components/Steps.tsx
@@ -1,0 +1,64 @@
+import { RenderFn } from 'editorjs-blocks-react-renderer';
+
+export interface StepItem {
+    title?: string;
+    content?: string;
+}
+
+export interface StepsData {
+    items?: StepItem[];
+}
+
+const Steps: RenderFn<StepsData> = ({ data, className = '' }) => {
+    const items = (data?.items || [])
+        .map((item) => ({
+            title: item?.title?.trim() || '',
+            content: item?.content?.trim() || '',
+        }))
+        .filter((item) => item.title !== '' || item.content !== '');
+
+    if (!items.length) {
+        return null;
+    }
+
+    return (
+        <section className={`${className} my-6 not-prose cdc-content-steps`} aria-label="Step list">
+            <div className="space-y-0" role="list">
+                {items.map((item, index) => (
+                    <div
+                        key={`${item.title}-${index}`}
+                        className="grid grid-cols-[2.75rem_minmax(0,1fr)] gap-4 pb-8 last:pb-0"
+                        role="listitem"
+                        data-step-index={index + 1}
+                    >
+                        <div className="flex flex-col items-center pt-0.5" aria-hidden="true">
+                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-foreground text-[13px] font-semibold text-background shadow-md">
+                                {index + 1}
+                            </div>
+                            {index < items.length - 1 ? <div className="mt-2 w-px flex-1 bg-border" /> : null}
+                        </div>
+
+                        <article className="min-w-0 pt-0.5">
+                            {item.title ? (
+                                <h3 className="m-0 text-[15px] font-medium leading-7 text-muted-foreground">
+                                    {item.title}
+                                </h3>
+                            ) : null}
+                            {item.content ? (
+                                <p
+                                    className={`m-0 whitespace-pre-line text-base leading-7 text-foreground ${
+                                        item.title ? 'mt-3' : 'mt-1'
+                                    }`}
+                                >
+                                    {item.content}
+                                </p>
+                            ) : null}
+                        </article>
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+};
+
+export default Steps;

--- a/packages/ottarenderer/src/index.ts
+++ b/packages/ottarenderer/src/index.ts
@@ -14,6 +14,7 @@ export { default as Map } from './components/Map';
 export { default as Quote } from './components/Quote';
 export { default as Review } from './components/Review';
 export { default as Spoiler } from './components/Spoiler';
+export { default as Steps } from './components/Steps';
 export { default as Table } from './components/Table';
 export { default as Warning } from './components/Warning';
 
@@ -26,6 +27,7 @@ export type { LayoutData, LayoutPreset } from './components/Layout';
 export type { MapData, MapProvider, MapTheme } from './components/Map';
 export type { QuoteData } from './components/Quote';
 export type { ReviewData } from './components/Review';
+export type { StepItem, StepsData } from './components/Steps';
 
 // Export configuration and utilities
 export { blockClass, customRenderers, defaultEJSRConfigs, shouldRenderContentBlocks } from './EditorJsRenderer';

--- a/packages/ottarenderer/src/styles.css
+++ b/packages/ottarenderer/src/styles.css
@@ -675,3 +675,84 @@
     border-color: #374151;
     background: #111827;
 }
+
+/* ======================================= */
+/* Steps Block Styles (fallback when Tailwind is absent) */
+/* ======================================= */
+
+.cdc-content-steps {
+    display: block;
+    clear: both;
+    margin: 1.5rem auto;
+    width: 100%;
+}
+
+.cdc-content-steps [role='list'] {
+    margin: 0;
+    padding: 0;
+}
+
+.cdc-content-steps [role='listitem'] {
+    display: grid;
+    grid-template-columns: 2.75rem minmax(0, 1fr);
+    gap: 1rem;
+    padding-bottom: 2rem;
+}
+
+.cdc-content-steps [role='listitem']:last-child {
+    padding-bottom: 0;
+}
+
+.cdc-content-steps [aria-hidden='true'] {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 0.125rem;
+}
+
+.cdc-content-steps [aria-hidden='true'] > div:first-child {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 9999px;
+    border: none;
+    background: hsl(var(--foreground));
+    color: hsl(var(--background));
+    font-size: 0.8rem;
+    font-weight: 600;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.cdc-content-steps [aria-hidden='true'] > div:nth-child(2) {
+    margin-top: 0.5rem;
+    width: 1px;
+    flex: 1;
+    background: hsl(var(--border));
+}
+
+.cdc-content-steps article {
+    min-width: 0;
+    padding-top: 0.125rem;
+}
+
+.cdc-content-steps h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    line-height: 1.7;
+    color: hsl(var(--muted-foreground));
+}
+
+.cdc-content-steps p {
+    margin: 0.75rem 0 0;
+    white-space: pre-line;
+    font-size: 1rem;
+    line-height: 1.7;
+    color: hsl(var(--foreground));
+}
+
+@media (prefers-color-scheme: dark) {
+    /* Steps block relies on theme variables; no extra overrides needed */
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a new 'Steps' editor plugin and renderer to provide a numbered timeline block.

---
<p><a href="https://cursor.com/agents/bc-6eb8a504-3661-4b71-b8cd-b17f047914d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eb8a504-3661-4b71-b8cd-b17f047914d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->